### PR TITLE
Update AppDelegate.swift

### DIFF
--- a/messaging/FCMSwift/AppDelegate.swift
+++ b/messaging/FCMSwift/AppDelegate.swift
@@ -63,7 +63,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   // [START refresh_token]
   func tokenRefreshNotificaiton(notification: NSNotification) {
-    let refreshedToken = FIRInstanceID.instanceID().token()!
+    let refreshedToken:String? = FIRInstanceID.instanceID().token()
     print("InstanceID token: \(refreshedToken)")
 
     // Connect to FCM since connection may have failed when attempted before having a token.


### PR DESCRIPTION
FIRInstanceID.instanceID().token()! cause crash the app from the quick-start example when the app is installed and launched first time on a real device.