### PR TITLE
[Swift sample] Fix for FCM notifications not going through on iOS 10 when app is in background

### DIFF
--- a/messaging/FCMSwift/AppDelegate.swift
+++ b/messaging/FCMSwift/AppDelegate.swift
@@ -45,9 +45,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       let settings: UIUserNotificationSettings =
       UIUserNotificationSettings(forTypes: [.Alert, .Badge, .Sound], categories: nil)
       application.registerUserNotificationSettings(settings)
-      application.registerForRemoteNotifications()
     }
 
+    application.registerForRemoteNotifications()
 
     // [END register_for_notifications]
 


### PR DESCRIPTION
We had a client project using the FCM on iOS 9 and everything worked fine. The push notifications always got through fantastically. But after updating the project to use Swift 3 and updating one of our test devices to iOS 10, suddenly the app didn't receive any push notifications when it was on background.

We struggled with this for a couple days, but then figured out after comparing the Objective C and Swift sample logic. The solution was embarrassingly simple.

[As seen here](https://github.com/firebase/quickstart-ios/blob/master/messaging/FCM/AppDelegate.m#L85), the Objective C sample for messaging has different behavior than the Swift one. The ```registerForRemoteNotifications``` function is called for **every iOS version above 7.1** (including iOS 10), but on the Swift sample it's **not called for iOS versions 10.0 and above**. Because of this, the notifications don't go through on iOS 10 when the app is in background, as only the delegates and authorization options are set.

## Steps to reproduce the bug

* ```pod try Firebase``` and select the option ```10``` when prompted. 
* Launch the Objective C version app on iPhone running iOS 10.
* Press the home button. Then send a sample Push notification to the device from the Firebase Console. Everything works properly and the push notification is shown, even though the app is in background.
* Now launch the Swift version app on iPhone running iOS 10.
* Press the home button. Then send a sample Push notification to the device from the Firebase Console. Nothing happens and the notification isn't shown. Once you open the app, the payload can be seen in the log though.