### PR TITLE
Attempt to make Swift sign in code easier to read

### DIFF
--- a/database/DatabaseExampleSwift/SignInViewController.swift
+++ b/database/DatabaseExampleSwift/SignInViewController.swift
@@ -38,18 +38,18 @@ class SignInViewController: UIViewController, UITextFieldDelegate {
   @IBAction func didTapEmailLogin(_ sender: AnyObject) {
   
     guard let email = self.emailField.text, let password = self.passwordField.text else {
-          self.showMessagePrompt("email/password can't be empty")
+      self.showMessagePrompt("email/password can't be empty")
       return
     }
     
-    showSpinner{}
+    self.showSpinner {}
     
     // Sign user in
     FIRAuth.auth()?.signIn(withEmail: email, password: password, completion: { (user, error) in
       
-      self.hideSpinner{}
+      self.hideSpinner {}
       
-      guard let user = user, (error == nil) else {
+      guard let user = user, error == nil else {
         self.showMessagePrompt(error!.localizedDescription)
         return
       }
@@ -62,7 +62,7 @@ class SignInViewController: UIViewController, UITextFieldDelegate {
           return
         }
         
-        // Otherwise, create a user in the database
+        // Otherwise, create the new user account
         self.showTextInputPrompt(withMessage: "Username:") { (userPressedOK, username) in
           
           guard let username = username else {
@@ -70,16 +70,17 @@ class SignInViewController: UIViewController, UITextFieldDelegate {
             return
           }
           
-          self.showSpinner{}
+          self.showSpinner {}
           
           let changeRequest = FIRAuth.auth()?.currentUser?.profileChangeRequest()
           changeRequest?.displayName = username
           
           changeRequest?.commitChanges() { (error) in
             
-            self.hideSpinner{}
-            guard error == nil else {
-              self.showMessagePrompt(error!.localizedDescription)
+            self.hideSpinner {}
+            
+            if let error = error {
+              self.showMessagePrompt(error.localizedDescription)
               return
             }
             
@@ -135,17 +136,17 @@ class SignInViewController: UIViewController, UITextFieldDelegate {
     func saveUser(_ user: FIRUser, withUsername username: String) {
       
       // Create a change request
-      showSpinner{}
-        let changeRequest = FIRAuth.auth()?.currentUser?.profileChangeRequest()
-        changeRequest?.displayName = username
+      self.showSpinner {}
+      let changeRequest = FIRAuth.auth()?.currentUser?.profileChangeRequest()
+      changeRequest?.displayName = username
       
       // Commit profile changes to server
       changeRequest?.commitChanges() { (error) in
           
-        self.hideSpinner{}
+        self.hideSpinner {}
           
-        guard error == nil else {
-          self.showMessagePrompt(error!.localizedDescription)
+        if let error = error {
+          self.showMessagePrompt(error.localizedDescription)
           return
         }
         


### PR DESCRIPTION
When I was first learning the ins and outs of Firebase, I came here to get a real-world, full example of how the Firebase code worked.

However, I was appalled at what I saw. 13 levels of indentation? **13**!?
And most were just nested `if let` statements -- not a `guard` anywhere to be found.

This pull request is my attempt at turning at least one of the classes into a more readable example, with added comments to explain what is going on (hopefully more helpful to a beginner) and with some pieces of code broken up into bite-sized functions. 

Note: the spinner code probably isn't implemented properly. I can't figure out why you'd call a hideSpinner *closure* inside the startSpinner closure. In particular, a [certain progress indicator framework](https://github.com/SVProgressHUD/SVProgressHUD) uses functions to start and stop the spinner. Is there a technical reason why that procedure couldn't be implemented here, or is just a design decision?

---

Aside from those changes, I have a question about the overall design of the app.
Why does the "Create account" procedure use dialog popups and not a simple static TableViewController? As a user, it's hard to follow, with constant animations popping up and going with no distinction between them and errors, and the code contains closure after closure after closure. 