### PR TITLE
Add explicit Entitlements for APNs required by XCode 8

### DIFF
--- a/messaging/FCM/FCM.entitlements
+++ b/messaging/FCM/FCM.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/messaging/FCMSwift/FCMSwift.entitlements
+++ b/messaging/FCMSwift/FCMSwift.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/messaging/README.md
+++ b/messaging/README.md
@@ -18,7 +18,10 @@ Getting Started
 - Update the app Bundle ID in XCode to match the Bundle ID of your APNs cert.
 - Run the sample on your iOS device.
 
-Note: You will need Swift 3.0 to run the Swift version of this quickstart.
+Note:
+- You will need Swift 3.0 to run the Swift version of this quickstart.
+- APS Environment Entitlements are required for remote notifications as of XCode 8.
+  Ensure that Push Notifications are on without error in App > Capabilities.
 
 Screenshots
 -----------

--- a/messaging/README.md
+++ b/messaging/README.md
@@ -15,12 +15,12 @@ Getting Started
 - Add APNS certs to your project in **Project Settings** > **Notifications** in the [console](https://console.firebase.google.com)
 - Run `pod install`
 - Copy in the GoogleServices-Info.plist to your project
-- Update the app Bundle ID in XCode to match the Bundle ID of your APNs cert.
+- Update the app Bundle ID in Xcode to match the Bundle ID of your APNs cert.
 - Run the sample on your iOS device.
 
 Note:
 - You will need Swift 3.0 to run the Swift version of this quickstart.
-- APS Environment Entitlements are required for remote notifications as of XCode 8.
+- APS Environment Entitlements are required for remote notifications as of Xcode 8.
   Ensure that Push Notifications are on without error in App > Capabilities.
 
 Screenshots


### PR DESCRIPTION
XCode 8 requires explicit entitlements for remote notifications.