### PR TITLE
Broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ for both Objective-C and Swift. For more information, see https://firebase.googl
 
 - [Admob](admob)
 - [Analytics](analytics)
-- [App Indexing](app-indexing)
 - [Authentication](authentication)
 - [Config](config)
 - [Crash Reporting](crashreporting)


### PR DESCRIPTION
Removed broken link since App Indexing subdirectory was removed in https://github.com/firebase/quickstart-ios/pull/121