### PR TITLE
Add check for message ID

### DIFF
--- a/messaging/MessagingExample/AppDelegate.m
+++ b/messaging/MessagingExample/AppDelegate.m
@@ -39,6 +39,8 @@
 
 @implementation AppDelegate
 
+NSString *const kGCMMessageIDKey = @"gcm.message_id";
+
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
@@ -102,7 +104,9 @@
   // TODO: Handle data of notification
 
   // Print message ID.
-  NSLog(@"Message ID: %@", userInfo[@"gcm.message_id"]);
+  if ([userInfo objectForKey:kGCMMessageIDKey]) {
+    NSLog(@"Message ID: %@", userInfo[kGCMMessageIDKey]);
+  }
 
   // Print full message.
   NSLog(@"%@", userInfo);
@@ -115,7 +119,9 @@
   // TODO: Handle data of notification
 
   // Print message ID.
-  NSLog(@"Message ID: %@", userInfo[@"gcm.message_id"]);
+  if ([userInfo objectForKey:kGCMMessageIDKey]) {
+    NSLog(@"Message ID: %@", userInfo[kGCMMessageIDKey]);
+  }
 
   // Print full message.
   NSLog(@"%@", userInfo);
@@ -131,7 +137,9 @@
          withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
   // Print message ID.
   NSDictionary *userInfo = notification.request.content.userInfo;
-  NSLog(@"Message ID: %@", userInfo[@"gcm.message_id"]);
+  if ([userInfo objectForKey:kGCMMessageIDKey]) {
+    NSLog(@"Message ID: %@", userInfo[kGCMMessageIDKey]);
+  }
 
   // Print full message.
   NSLog(@"%@", userInfo);
@@ -142,6 +150,11 @@
 didReceiveNotificationResponse:(UNNotificationResponse *)response
          withCompletionHandler:(void (^)())completionHandler {
   NSDictionary *userInfo = response.notification.request.content.userInfo;
+  if ([userInfo objectForKey:kGCMMessageIDKey]) {
+    NSLog(@"Message ID: %@", userInfo[kGCMMessageIDKey]);
+  }
+
+  // Print full message.
   NSLog(@"%@", userInfo);
 }
 #endif

--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -25,6 +25,7 @@ import FirebaseMessaging
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var window: UIWindow?
+  let gcmMessageIDKey = "gcm.message_id"
 
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
@@ -69,7 +70,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // TODO: Handle data of notification
 
     // Print message ID.
-    print("Message ID: \(userInfo["gcm.message_id"]!)")
+    if userInfo[gcmMessageIDKey] != nil {
+      print("Message ID: \(userInfo[gcmMessageIDKey]!)")
+    }
 
     // Print full message.
     print(userInfo)
@@ -82,7 +85,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // TODO: Handle data of notification
 
     // Print message ID.
-    print("Message ID: \(userInfo["gcm.message_id"]!)")
+    if userInfo[gcmMessageIDKey] != nil {
+      print("Message ID: \(userInfo[gcmMessageIDKey]!)")
+    }
 
     // Print full message.
     print(userInfo)
@@ -148,7 +153,9 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
     withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
     let userInfo = notification.request.content.userInfo
     // Print message ID.
-    print("Message ID: \(userInfo["gcm.message_id"]!)")
+    if userInfo[gcmMessageIDKey] != nil {
+      print("Message ID: \(userInfo[gcmMessageIDKey]!)")
+    }
 
     // Print full message.
     print(userInfo)
@@ -159,7 +166,9 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
                               withCompletionHandler completionHandler: @escaping () -> Void) {
     let userInfo = response.notification.request.content.userInfo
     // Print message ID.
-    print("Message ID: \(userInfo["gcm.message_id"]!)")
+    if userInfo[gcmMessageIDKey] != nil {
+      print("Message ID: \(userInfo[gcmMessageIDKey]!)")
+    }
 
     // Print full message.
     print(userInfo)

--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -70,8 +70,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // TODO: Handle data of notification
 
     // Print message ID.
-    if userInfo[gcmMessageIDKey] != nil {
-      print("Message ID: \(userInfo[gcmMessageIDKey]!)")
+    if let messageID = userInfo[gcmMessageIDKey] {
+      print("Message ID: \(messageID)")
     }
 
     // Print full message.
@@ -85,8 +85,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // TODO: Handle data of notification
 
     // Print message ID.
-    if userInfo[gcmMessageIDKey] != nil {
-      print("Message ID: \(userInfo[gcmMessageIDKey]!)")
+    if let messageID = userInfo[gcmMessageIDKey] {
+      print("Message ID: \(messageID)")
     }
 
     // Print full message.
@@ -153,8 +153,8 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
     withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
     let userInfo = notification.request.content.userInfo
     // Print message ID.
-    if userInfo[gcmMessageIDKey] != nil {
-      print("Message ID: \(userInfo[gcmMessageIDKey]!)")
+    if let messageID = userInfo[gcmMessageIDKey] {
+      print("Message ID: \(messageID)")
     }
 
     // Print full message.
@@ -166,8 +166,8 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
                               withCompletionHandler completionHandler: @escaping () -> Void) {
     let userInfo = response.notification.request.content.userInfo
     // Print message ID.
-    if userInfo[gcmMessageIDKey] != nil {
-      print("Message ID: \(userInfo[gcmMessageIDKey]!)")
+    if let messageID = userInfo[gcmMessageIDKey] {
+      print("Message ID: \(messageID)")
     }
 
     // Print full message.


### PR DESCRIPTION
Avoid crashes if non FCM messages, those without a message ID, are received.