### PR TITLE
Fix incorrect FCM connection logic

### DIFF
--- a/messaging/MessagingExample/AppDelegate.m
+++ b/messaging/MessagingExample/AppDelegate.m
@@ -187,6 +187,13 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
 
 // [START connect_to_fcm]
 - (void)connectToFcm {
+  if (![[FIRInstanceID instanceID] token]) {
+    return;
+  }
+
+  // Disconnect previous FCM connection if it exists.
+  [[FIRMessaging messaging] disconnect];
+
   [[FIRMessaging messaging] connectWithCompletion:^(NSError * _Nullable error) {
     if (error != nil) {
       NSLog(@"Unable to connect to FCM. %@", error);

--- a/messaging/MessagingExample/AppDelegate.m
+++ b/messaging/MessagingExample/AppDelegate.m
@@ -187,6 +187,7 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
 
 // [START connect_to_fcm]
 - (void)connectToFcm {
+  // Won't connect since there is no token
   if (![[FIRInstanceID instanceID] token]) {
     return;
   }

--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -107,6 +107,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   // [START connect_to_fcm]
   func connectToFcm() {
+    // Won't connect since there is no token
     guard FIRInstanceID.instanceID().token() != nil else {
       return;
     }

--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -107,6 +107,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   // [START connect_to_fcm]
   func connectToFcm() {
+    guard FIRInstanceID.instanceID().token() != nil else {
+      return;
+    }
+
+    // Disconnect previous FCM connection if it exists.
+    FIRMessaging.messaging().disconnect()
+
     FIRMessaging.messaging().connect { (error) in
       if error != nil {
         print("Unable to connect with FCM. \(error)")


### PR DESCRIPTION
Prior to this, when running the Example app for the first time, the
following error was being printed in the console:

Unable to connect to FCM. Error Domain=com.google.fcm Code=501 "(null)"

After accepting the notifications permission, the following error was
being printed in the console:

Unable to connect to FCM. Error Domain=com.google.fcm Code=2001 "(null)"

The first error means that the app tried to connect to FCM while there
was no Firebase registration token available. It now checks for the
current token and exits early if it's null.

The second error means that the app tried to connect to FCM while
another connection is already available. It now disconnects from any
existing connection prior to trying to connect again.

The better solution would be to have an `isConnected` property on the
`FIRMessaging` shared instance and if it is set to `YES`, exit early
instead of re-connecting to FCM.

This could also be achieved by a similar private property in the
`AppDelegate` class but I though that would be outside the example's
scope and having only parts of the code in the documentation would make
users not to understand it properly.

I also don't understand the reasoning behind these cryptic errors.
Firstly, the error codes should be added to an errors enum. Secondly,
an error message would immensely help, instead of those null values.

Even with these added, I don't understand the "call methods and ignore
the errors in case of problems" reasoning behind this Example, when they
could be avoided. It took me days to figure out what those errors really
mean.