### PR TITLE
Add note about notification permission dialog

### DIFF
--- a/messaging/MessagingExample/AppDelegate.m
+++ b/messaging/MessagingExample/AppDelegate.m
@@ -44,7 +44,8 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
-  // Register for remote notifications
+  // Register for remote notifications. This shows a permission dialog on first run, to
+  // show the dialog at a more appropriate time move this registration accordingly.
   if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_7_1) {
     // iOS 7.1 or earlier. Disable the deprecation warnings.
     #pragma clang diagnostic push
@@ -73,8 +74,7 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
           | UNAuthorizationOptionBadge;
       [[UNUserNotificationCenter currentNotificationCenter]
           requestAuthorizationWithOptions:authOptions
-          completionHandler:^(BOOL granted, NSError * _Nullable error) {
-          }
+            
        ];
 
       // For iOS 10 display notification (sent via APNS)

--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -30,6 +30,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
+    // Register for remote notifications. This shows a permission dialog on first run, to
+    // show the dialog at a more appropriate time move this registration accordingly.
     // [START register_for_notifications]
     if #available(iOS 10.0, *) {
       let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]

--- a/messaging/README.md
+++ b/messaging/README.md
@@ -9,6 +9,15 @@ Introduction
 
 - [Read more about Firebase Messaging](https://firebase.google.com/docs/cloud-messaging)
 
+Best Practices
+--------------
+
+- In this sample the request for permission to receive remote notifications
+  is made on first run, this results in a permission dialog on first run.
+  Most apps would want that dialog to be shown at a more appropriate time. So
+  move the registration for remote notifications to a more appropriate place in
+  your app.
+
 Getting Started
 ---------------
 


### PR DESCRIPTION
This sample registers for remote notifications on first run,
if this is not desirable it should be moved to a more appropriate
place so the dialog is shown at a more appropriate time.

Resolves #184 