### PR TITLE
Fix receiving push notification on iOS 10

### DIFF
--- a/messaging/MessagingExample/AppDelegate.m
+++ b/messaging/MessagingExample/AppDelegate.m
@@ -68,6 +68,8 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
     } else {
       // iOS 10 or later
       #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+      // For iOS 10 display notification (sent via APNS)
+      [UNUserNotificationCenter currentNotificationCenter].delegate = self;
       UNAuthorizationOptions authOptions =
           UNAuthorizationOptionAlert
           | UNAuthorizationOptionSound
@@ -75,8 +77,6 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
       [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:authOptions completionHandler:^(BOOL granted, NSError * _Nullable error) {
           }];
 
-      // For iOS 10 display notification (sent via APNS)
-      [UNUserNotificationCenter currentNotificationCenter].delegate = self;
       // For iOS 10 data message (sent via FCM)
       [FIRMessaging messaging].remoteMessageDelegate = self;
       #endif

--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -34,13 +34,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // show the dialog at a more appropriate time move this registration accordingly.
     // [START register_for_notifications]
     if #available(iOS 10.0, *) {
+      // For iOS 10 display notification (sent via APNS)
+      UNUserNotificationCenter.current().delegate = self
+
       let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
       UNUserNotificationCenter.current().requestAuthorization(
         options: authOptions,
         completionHandler: {_, _ in })
 
-      // For iOS 10 display notification (sent via APNS)
-      UNUserNotificationCenter.current().delegate = self
       // For iOS 10 data message (sent via FCM)
       FIRMessaging.messaging().remoteMessageDelegate = self
 


### PR DESCRIPTION
Delegate should set before asynchronous `requestAuthorizationWithOptions`. It fixes #194. 