### PR TITLE
Update Messaging samples for subtle 2.0.0 SDK changes

### DIFF
--- a/messaging/MessagingExample/AppDelegate.m
+++ b/messaging/MessagingExample/AppDelegate.m
@@ -94,6 +94,9 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
   // this callback will not be fired till the user taps on the notification launching the application.
   // TODO: Handle data of notification
 
+  // With swizzling disabled you must let Messaging know about the message, for Analytics
+  // [[Messaging messaging] appDidReceiveMessage:userInfo];
+
   // Print message ID.
   if (userInfo[kGCMMessageIDKey]) {
     NSLog(@"Message ID: %@", userInfo[kGCMMessageIDKey]);
@@ -108,6 +111,9 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
   // If you are receiving a notification message while your app is in the background,
   // this callback will not be fired till the user taps on the notification launching the application.
   // TODO: Handle data of notification
+
+  // With swizzling disabled you must let Messaging know about the message, for Analytics
+  // [[Messaging messaging] appDidReceiveMessage:userInfo];
 
   // Print message ID.
   if (userInfo[kGCMMessageIDKey]) {
@@ -128,8 +134,12 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
        willPresentNotification:(UNNotification *)notification
          withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
-  // Print message ID.
   NSDictionary *userInfo = notification.request.content.userInfo;
+
+  // With swizzling disabled you must let Messaging know about the message, for Analytics
+  // [[Messaging messaging] appDidReceiveMessage:userInfo];
+
+  // Print message ID.
   if (userInfo[kGCMMessageIDKey]) {
     NSLog(@"Message ID: %@", userInfo[kGCMMessageIDKey]);
   }
@@ -169,6 +179,14 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
 }
 // [END refresh_token]
 
+// [START ios_10_data_message]
+// Receive data messages on iOS 10+ directly from FCM (bypassing APNs) when the app is in the foreground.
+// To enable direct data messages, you can set [Messaging messaging].shouldEstablishDirectChannel to YES.
+- (void)messaging:(FIRMessaging *)messaging didReceiveMessage:(FIRMessagingRemoteMessage *)remoteMessage {
+  NSLog(@"Received data message: %@", remoteMessage.appData);
+}
+// [END ios_10_data_message]
+
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
   NSLog(@"Unable to register for remote notifications: %@", error);
 }
@@ -180,6 +198,6 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
   NSLog(@"APNs device token retrieved: %@", deviceToken);
 
   // With swizzling disabled you must set the APNs device token here.
-  // [[FIRInstanceID instanceID] setAPNSToken:deviceToken type:FIRInstanceIDAPNSTokenTypeSandbox];
+  // [Messaging messaging].APNSToken = deviceToken;
 }
 @end

--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -64,6 +64,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // this callback will not be fired till the user taps on the notification launching the application.
     // TODO: Handle data of notification
 
+    // With swizzling disabled you must let Messaging know about the message, for Analytics
+    // Messaging.messaging().appDidReceiveMessage(userInfo)
+
     // Print message ID.
     if let messageID = userInfo[gcmMessageIDKey] {
       print("Message ID: \(messageID)")
@@ -78,6 +81,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // If you are receiving a notification message while your app is in the background,
     // this callback will not be fired till the user taps on the notification launching the application.
     // TODO: Handle data of notification
+
+    // With swizzling disabled you must let Messaging know about the message, for Analytics
+    // Messaging.messaging().appDidReceiveMessage(userInfo)
 
     // Print message ID.
     if let messageID = userInfo[gcmMessageIDKey] {
@@ -97,12 +103,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   // This function is added here only for debugging purposes, and can be removed if swizzling is enabled.
   // If swizzling is disabled then this function must be implemented so that the APNs token can be paired to
-  // the InstanceID token.
+  // the FCM registration token.
   func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
     print("APNs token retrieved: \(deviceToken)")
 
     // With swizzling disabled you must set the APNs token here.
-    // FIRInstanceID.instanceID().setAPNSToken(deviceToken, type: FIRInstanceIDAPNSTokenType.sandbox)
+    // Messaging.messaging().apnsToken = deviceToken
   }
 }
 
@@ -115,6 +121,10 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
                               willPresent notification: UNNotification,
     withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
     let userInfo = notification.request.content.userInfo
+
+    // With swizzling disabled you must let Messaging know about the message, for Analytics
+    // Messaging.messaging().appDidReceiveMessage(userInfo)
+
     // Print message ID.
     if let messageID = userInfo[gcmMessageIDKey] {
       print("Message ID: \(messageID)")
@@ -151,5 +161,13 @@ extension AppDelegate : MessagingDelegate {
     print("Firebase registration token: \(fcmToken)")
   }
   // [END refresh_token]
+
+  // [START ios_10_data_message]
+  // Receive data messages on iOS 10+ directly from FCM (bypassing APNs) when the app is in the foreground.
+  // To enable direct data messages, you can set Messaging.messaging().shouldEstablishDirectChannel to true.
+  func messaging(_ messaging: Messaging, didReceive remoteMessage: MessagingRemoteMessage) {
+    print("Received data message: \(remoteMessage.appData)")
+  }
+  // [END ios_10_data_message]
 }
 


### PR DESCRIPTION
This updates the sample with some subtle changes in the 2.0.0 SDK that we missed during the initial docs update:
1. It updates the comment about setting the APNs token directly with Messaging instead of InstanceID
2. It adds commented-out lines to show where appDidReceiveMessage: is supposed to be called (similar to the commented-out line about setting the APNs token if swizzling is disabled
3. It adds the iOS 10 delegate handler for data messages, to serve as an example for developers following the app as a template for their own apps