### PR TITLE
Call configure before registering w/ notifications

### DIFF
--- a/messaging/MessagingExample/AppDelegate.m
+++ b/messaging/MessagingExample/AppDelegate.m
@@ -38,6 +38,13 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+  // [START configure_firebase]
+  [FIRApp configure];
+  // [END configure_firebase]
+
+  // [START set_messaging_delegate]
+  [FIRMessaging messaging].delegate = self;
+  // [END set_messaging_delegate]
 
   // Register for remote notifications. This shows a permission dialog on first run, to
   // show the dialog at a more appropriate time move this registration accordingly.
@@ -77,14 +84,6 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
     [[UIApplication sharedApplication] registerForRemoteNotifications];
     // [END register_for_notifications]
   }
-
-  // [START configure_firebase]
-  [FIRApp configure];
-  // [END configure_firebase]
-
-  // [START set_messaging_delegate]
-  [FIRMessaging messaging].delegate = self;
-  // [END set_messaging_delegate]
   return YES;
 }
 

--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -28,6 +28,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
+    FirebaseApp.configure()
+
+    // [START set_messaging_delegate]
+    Messaging.messaging().delegate = self
+    // [END set_messaging_delegate]
+
     // Register for remote notifications. This shows a permission dialog on first run, to
     // show the dialog at a more appropriate time move this registration accordingly.
     // [START register_for_notifications]
@@ -48,12 +54,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     application.registerForRemoteNotifications()
 
     // [END register_for_notifications]
-
-    FirebaseApp.configure()
-
-    // [START set_messaging_delegate]
-    Messaging.messaging().delegate = self
-    // [END set_messaging_delegate]
 
     return true
   }


### PR DESCRIPTION
This helps us avoid a potential race condition where iOS could return an APNs token before Firebase (and FIRMessaging) has been configured, potentially not associating the APNs token with the FCM token.