### PR TITLE
Fixes MessagingExample compile error

### DIFF
--- a/messaging/MessagingExample/AppDelegate.m
+++ b/messaging/MessagingExample/AppDelegate.m
@@ -42,7 +42,7 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
   // [END configure_firebase]
 
   // [START set_messaging_delegate]
-  [FIRMessaging messaging].delegate = self;
+  [FIRMessaging messaging].remoteMessageDelegate = self;
   // [END set_messaging_delegate]
 
   // Register for remote notifications. This shows a permission dialog on first run, to


### PR DESCRIPTION
Fixes MessagingExample compile error using remoteMessageDelegate property instead of delegate

Fixes issue #363 