### PR TITLE
Use FCM didReceiveRegistrationToken

### DIFF
--- a/messaging/MessagingExample/AppDelegate.m
+++ b/messaging/MessagingExample/AppDelegate.m
@@ -171,13 +171,11 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
 // [END ios_10_message_handling]
 
 // [START refresh_token]
-- (void)messaging:(nonnull FIRMessaging *)messaging didRefreshRegistrationToken:(nonnull NSString *)fcmToken {
-  // Note that this callback will be fired everytime a new token is generated, including the first
-  // time. So if you need to retrieve the token as soon as it is available this is where that
-  // should be done.
-  NSLog(@"FCM registration token: %@", fcmToken);
+- (void)messaging:(FIRMessaging *)messaging didReceiveRegistrationToken:(NSString *)fcmToken {
+    NSLog(@"FCM registration token: %@", fcmToken);
 
-  // TODO: If necessary send token to application server.
+    // TODO: If necessary send token to application server.
+    // Note: This callback is fired at each app startup and whenever a new token is generated.
 }
 // [END refresh_token]
 

--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -157,8 +157,11 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
 
 extension AppDelegate : MessagingDelegate {
   // [START refresh_token]
-  func messaging(_ messaging: Messaging, didRefreshRegistrationToken fcmToken: String) {
+  func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
     print("Firebase registration token: \(fcmToken)")
+
+    // TODO: If necessary send token to application server.
+    // Note: This callback is fired at each app startup and whenever a new token is generated.
   }
   // [END refresh_token]
 


### PR DESCRIPTION
On each app startup and whenever the token changes
didReceiveRegistrationToken is fired. This is the
recommended way of being updated about the most
current FCM registration token.

Merge this PR only when a pod including [this change](https://github.com/firebase/firebase-ios-sdk/commit/2b40693be4c9aa2c94b668fb144c6993f557b8d6) is available.