### PR TITLE
Fixes encoding.

### DIFF
--- a/performance/PerformanceExample/ViewController.m
+++ b/performance/PerformanceExample/ViewController.m
@@ -87,7 +87,7 @@
       NSString *contentToWrite = [contents stringByAppendingString:response.URL.absoluteString];
       [contentToWrite writeToFile:fileName
                        atomically:NO
-                         encoding:NSStringEncodingConversionAllowLossy
+                         encoding:NSUTF8StringEncoding
                             error:nil];
     }] resume];
 


### PR DESCRIPTION
If file is read in NSUTF8StringEncoding, I don't think it's right to write it in NSStringEncodingConversionAllowLossy.