### PR TITLE
[MLKit] multiplied device screen scale

### DIFF
--- a/mlkit/MLKitExample/ViewController.swift
+++ b/mlkit/MLKitExample/ViewController.swift
@@ -947,11 +947,11 @@ class ViewController:  UIViewController,  UIImagePickerControllerDelegate,  UINa
     var scaledImageHeight: CGFloat = 0.0
     switch orientation {
     case .portrait, .portraitUpsideDown, .unknown:
-      scaledImageWidth = imageView.bounds.size.width
+      scaledImageWidth = imageView.bounds.size.width * UIScreen.main.scale
       scaledImageHeight = image.size.height * scaledImageWidth / image.size.width
     case .landscapeLeft, .landscapeRight:
       scaledImageWidth = image.size.width * scaledImageHeight / image.size.height
-      scaledImageHeight = imageView.bounds.size.height
+      scaledImageHeight = imageView.bounds.size.height * UIScreen.main.scale
     }
     DispatchQueue.global(qos: .userInitiated).async {
       // Scale image while maintaining aspect ratio so it displays better in the UIImageView.


### PR DESCRIPTION
To show image more clearly, multiply device screen scale to image view size.

Before:
![img_2333](https://user-images.githubusercontent.com/20222809/39790698-6157a492-52ec-11e8-956e-0fb6e13b16d9.PNG)

After:
![img_2332](https://user-images.githubusercontent.com/20222809/39790700-63dfec06-52ec-11e8-814d-1ba7b95370cc.PNG)
