### PR TITLE
Added labels that display FCM tokens

### DIFF
--- a/messaging/MessagingExample/AppDelegate.m
+++ b/messaging/MessagingExample/AppDelegate.m
@@ -147,7 +147,10 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
 // [START refresh_token]
 - (void)messaging:(FIRMessaging *)messaging didReceiveRegistrationToken:(NSString *)fcmToken {
     NSLog(@"FCM registration token: %@", fcmToken);
-
+    // Notify about received token.
+    NSDictionary *dataDict = [NSDictionary dictionaryWithObject:fcmToken forKey:@"token"];
+    [[NSNotificationCenter defaultCenter] postNotificationName:
+     @"FCMToken" object:nil userInfo:dataDict];
     // TODO: If necessary send token to application server.
     // Note: This callback is fired at each app startup and whenever a new token is generated.
 }

--- a/messaging/MessagingExample/Base.lproj/Main.storyboard
+++ b/messaging/MessagingExample/Base.lproj/Main.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10109" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="dvH-Ce-6yG">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="dvH-Ce-6yG">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10083"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--FCM Example-->
@@ -14,11 +18,11 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="S9T-hp-Ka1">
-                                <rect key="frame" x="220" y="278" width="160" height="44"/>
+                                <rect key="frame" x="107.5" y="311.5" width="160" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="Grv-Ur-3qm"/>
                                     <constraint firstAttribute="width" constant="160" id="ggk-PO-zor"/>
@@ -31,42 +35,69 @@
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HgF-jF-1NC">
                                 <rect key="frame" x="204" y="233" width="192" height="44"/>
-                                <color key="backgroundColor" red="1" green="0.56078431370000004" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" red="1" green="0.56078431370000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="192" id="4Yd-c9-aCb"/>
                                     <constraint firstAttribute="height" constant="44" id="gyc-AL-1xz"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <state key="normal" title="Subscribe To News">
-                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="handleSubscribeTouch:" destination="BYZ-38-t0r" eventType="touchUpInside" id="meX-vb-HDO"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No FCM token" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RBg-uJ-gCV">
+                                <rect key="frame" x="67.5" y="459" width="240" height="14"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="240" id="R9g-We-nKc"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No InstanceID token" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1wF-0v-e01">
+                                <rect key="frame" x="67" y="565" width="240" height="13.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="240" id="FXq-Tm-sRh"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="1wF-0v-e01" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="0wR-rN-VBn"/>
+                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="RBg-uJ-gCV" secondAttribute="bottom" constant="194" id="4Cj-3x-9JW"/>
+                            <constraint firstItem="RBg-uJ-gCV" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="7XG-os-4BL"/>
+                            <constraint firstItem="RBg-uJ-gCV" firstAttribute="top" secondItem="S9T-hp-Ka1" secondAttribute="bottom" constant="103.5" id="dJ0-an-jgk"/>
                             <constraint firstItem="S9T-hp-Ka1" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="eqV-Gc-7aa"/>
                             <constraint firstItem="S9T-hp-Ka1" firstAttribute="top" secondItem="HgF-jF-1NC" secondAttribute="bottom" constant="8" id="izK-fQ-Uu7"/>
+                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="1wF-0v-e01" secondAttribute="bottom" constant="88.5" id="p2q-F9-Mpu"/>
                             <constraint firstItem="HgF-jF-1NC" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="st1-B5-WH3"/>
                             <constraint firstItem="S9T-hp-Ka1" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="wHX-8g-0MB"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="FCM Example" id="uI5-jL-nrY"/>
+                    <connections>
+                        <outlet property="fcmTokenMessage" destination="RBg-uJ-gCV" id="FUs-GZ-mfF"/>
+                        <outlet property="instanceIDTokenMessage" destination="1wF-0v-e01" id="Dmb-Lh-hLD"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="312" y="446"/>
+            <point key="canvasLocation" x="311.19999999999999" y="445.72713643178412"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="BBa-0w-b0R">
             <objects>
                 <navigationController id="dvH-Ce-6yG" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="FZU-Jb-Wzn">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="barTintColor" red="0.0" green="0.52156862745098043" blue="0.88627450980392153" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="barTintColor" red="0.0" green="0.52156862745098043" blue="0.88627450980392153" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>
                     <connections>
                         <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="Sil-bt-Y94"/>

--- a/messaging/MessagingExample/ViewController.h
+++ b/messaging/MessagingExample/ViewController.h
@@ -17,4 +17,6 @@
 @import UIKit;
 
 @interface ViewController : UIViewController
+@property (weak, nonatomic) IBOutlet UILabel *fcmTokenMessage;
+@property (weak, nonatomic) IBOutlet UILabel *instanceIDTokenMessage;
 @end

--- a/messaging/MessagingExample/ViewController.m
+++ b/messaging/MessagingExample/ViewController.m
@@ -19,12 +19,22 @@
 
 @implementation ViewController
 
+-(void)viewDidLoad {
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                        selector:@selector(displayFCMToken:)
+                                        name:@"FCMToken"
+                                        object:nil];
+}
+
 - (IBAction)handleLogTokenTouch:(id)sender {
   // [START log_fcm_reg_token]
   NSString *fcmToken = [FIRMessaging messaging].FCMToken;
   NSLog(@"Local FCM registration token: %@", fcmToken);
   // [END log_fcm_reg_token]
-
+    
+  NSString* displayToken = [NSString stringWithFormat:@"Logged FCM token: %@", fcmToken];
+  self.fcmTokenMessage.text = displayToken;
+    
   // [START log_iid_reg_token]
   [[FIRInstanceID instanceID] instanceIDWithHandler:^(FIRInstanceIDResult * _Nullable result,
                                                       NSError * _Nullable error) {
@@ -32,6 +42,9 @@
       NSLog(@"Error fetching remote instance ID: %@", error);
     } else {
       NSLog(@"Remote instance ID token: %@", result.token);
+      NSString* message =
+        [NSString stringWithFormat:@"Remote InstanceID token: %@", result.token];
+      self.instanceIDTokenMessage.text = message;
     }
   }];
   // [END log_iid_reg_token]
@@ -44,6 +57,12 @@
     NSLog(@"Subscribed to news topic");
   }];
   // [END subscribe_topic]
+}
+
+- (void) displayFCMToken:(NSNotification *) notification {
+  NSString* message =
+    [NSString stringWithFormat:@"Received FCM token: %@", notification.userInfo[@"token"]];
+  self.fcmTokenMessage.text = message;
 }
 
 @end

--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -159,7 +159,9 @@ extension AppDelegate : MessagingDelegate {
   // [START refresh_token]
   func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
     print("Firebase registration token: \(fcmToken)")
-
+    
+    let dataDict:[String: String] = ["token": fcmToken]
+    NotificationCenter.default.post(name: Notification.Name("FCMToken"), object: nil, userInfo: dataDict)
     // TODO: If necessary send token to application server.
     // Note: This callback is fired at each app startup and whenever a new token is generated.
   }

--- a/messaging/MessagingExampleSwift/ViewController.swift
+++ b/messaging/MessagingExampleSwift/ViewController.swift
@@ -19,12 +19,21 @@ import Firebase
 
 @objc(ViewController)
 class ViewController: UIViewController {
-
+ 
+  @IBOutlet weak var fcmTokenMessage: UILabel!
+  @IBOutlet weak var instanceIDTokenMessage: UILabel!
+    
+  override func viewDidLoad() {
+    NotificationCenter.default.addObserver(self, selector: #selector(self.displayFCMToken(notification:)),
+                                           name: Notification.Name("FCMToken"), object: nil)
+  }
+    
   @IBAction func handleLogTokenTouch(_ sender: UIButton) {
     // [START log_fcm_reg_token]
     let token = Messaging.messaging().fcmToken
     print("FCM token: \(token ?? "")")
     // [END log_fcm_reg_token]
+    self.fcmTokenMessage.text  = "Logged FCM token: \(token ?? "")"
 
     // [START log_iid_reg_token]
     InstanceID.instanceID().instanceID { (result, error) in
@@ -32,6 +41,7 @@ class ViewController: UIViewController {
         print("Error fetching remote instange ID: \(error)")
       } else if let result = result {
         print("Remote instance ID token: \(result.token)")
+        self.instanceIDTokenMessage.text  = "Remote InstanceID token: \(result.token)"
       }
     }
     // [END log_iid_reg_token]
@@ -45,4 +55,10 @@ class ViewController: UIViewController {
     // [END subscribe_topic]
   }
 
+  func displayFCMToken(notification: NSNotification){
+    guard let userInfo = notification.userInfo else {return}
+    if let fcmToken = userInfo["token"] as? String {
+      self.fcmTokenMessage.text = "Received FCM token: \(fcmToken)"
+    }
+  }
 }


### PR DESCRIPTION
for automation purposes we'd like to display FCM tokens on UI:
- when it's initially received
- when it's requested via [FIRMessaging messaging].FCMToken
- when it's requested via  [[FIRInstanceID instanceID] instanceIDWithHandler:

implemented for both ObjC and Swift apps