### PR TITLE
Enable AnalyticsExampleUITests target

### DIFF
--- a/analytics/AnalyticsExample.xcodeproj/xcshareddata/xcschemes/AnalyticsExample.xcscheme
+++ b/analytics/AnalyticsExample.xcodeproj/xcshareddata/xcschemes/AnalyticsExample.xcscheme
@@ -39,7 +39,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "107347FB20333AD6004A66D1"


### PR DESCRIPTION
Enable back AnalyticsExampleUITests target (so that it's consistent with all other targets)
It was mistakenly set as "skipped=yes" previously.