### PR TITLE
Updated the create_user snippet 

### DIFF
--- a/authentication/AuthenticationExampleSwift/EmailViewController.swift
+++ b/authentication/AuthenticationExampleSwift/EmailViewController.swift
@@ -111,6 +111,7 @@ class EmailViewController: UIViewController {
             self.showSpinner {
               // [START create_user]
               Auth.auth().createUser(withEmail: email, password: password) { (authResult, error) in
+                guard let user = authResult?.user else { return }
                 // [START_EXCLUDE]
                 self.hideSpinner {
                   guard let email = authResult?.user.email, error == nil else {


### PR DESCRIPTION
Updated the create_user snippet to include a line showing how to access the user from the `authResult` object. I suggest this based upon multiple developers on SO who have been confused and thought `authResul`t was itself of type `User` instead of `AuthDataResult`. Here are a couple examples of this confusion:
https://stackoverflow.com/questions/51589895/value-of-type-authdataresult-has-no-member-providerid-firebase-5-0/51600266#51600266
https://stackoverflow.com/questions/51409307/firebase-swift-4-authdataresult-eror/51409688#51409688
While the function itself doesn't then use the "user" created, the snippet will appear in the guides, so I think it's worth it to prevent some further confusion. If you have suggestions for other ways we could demonstrate this in the code, I'm up for suggestions.
