### PR TITLE
Import missing 'FirebaseMessaging' packages

### DIFF
--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -18,6 +18,7 @@ import UIKit
 import UserNotifications
 
 import Firebase
+import FirebaseMessaging
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {


### PR DESCRIPTION
If you use the current sample code, a build error will occur.
ex)
```
Messaging.messaging().delegate = self
```
Use of unresolved identifier 'Messaging'

I think you need to import 'FirebaseMessaging' package.