### PR TITLE
Comments out line which is supposed to be commented out.

### DIFF
--- a/authentication/AuthenticationExample/MainViewController.m
+++ b/authentication/AuthenticationExample/MainViewController.m
@@ -414,7 +414,7 @@ static NSString *const kUpdatePhoneNumberText = @"Update Phone Number";
 
   // Authenticate Game Center Local Player
   // Uncomment to sign in with Game Center
-  [self authenticateGameCenterLocalPlayer];
+  // [self authenticateGameCenterLocalPlayer];
 }
 
 - (void)setTitleDisplay: (FIRUser *)user {


### PR DESCRIPTION
This makes Objective-C authentication example work reasonably and match Swift example.