### PR TITLE
Replace 'didReceiveRegistrationToken'

### DIFF
--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -157,7 +157,7 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
 
 extension AppDelegate : MessagingDelegate {
   // [START refresh_token]
-  func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
+  func messaging(_ messaging: Messaging, didRefreshRegistrationToken fcmToken: String) {
     print("Firebase registration token: \(fcmToken)")
     
     let dataDict:[String: String] = ["token": fcmToken]


### PR DESCRIPTION
Method 'messaging(_:didReceiveRegistrationToken:)' has different argument labels from those required by protocol 'MessagingDelegate' ('messaging(_:didRefreshRegistrationToken:)')

Replace 'didReceiveRegistrationToken' with 'didRefreshRegistrationToken'