### PR TITLE
[5-2336000026166] RegEx condition not working for User property. Working example.

### DIFF
--- a/config/ConfigExample.xcodeproj/project.pbxproj
+++ b/config/ConfigExample.xcodeproj/project.pbxproj
@@ -3,10 +3,14 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00312B4FEE2D84BAFB635620 /* Pods_ConfigExample_ConfigExampleUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49CEDA70E7583B8DAE18D797 /* Pods_ConfigExample_ConfigExampleUITests.framework */; };
+		344D9591B717041661383210 /* Pods_ConfigExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8452FC76371B8672A9379FD /* Pods_ConfigExampleTests.framework */; };
+		3F08EE70257D5B900068360A /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3F08EE6F257D5B900068360A /* GoogleService-Info.plist */; };
+		D460E27621DA582FC06DEA59 /* Pods_ConfigExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11AA92BE67A2FBCE7AD24302 /* Pods_ConfigExample.framework */; };
 		EA062D6024A13966006714D3 /* RemoteConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA062D5F24A13966006714D3 /* RemoteConfigView.swift */; };
 		EA20B48A2497CC9D00B5E581 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA20B4892497CC9D00B5E581 /* AppDelegate.swift */; };
 		EA20B48C2497CC9D00B5E581 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA20B48B2497CC9D00B5E581 /* SceneDelegate.swift */; };
@@ -39,6 +43,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		11AA92BE67A2FBCE7AD24302 /* Pods_ConfigExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ConfigExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2EB24F18CE92E7D4CBFDEE3C /* Pods-ConfigExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ConfigExample.release.xcconfig"; path = "Target Support Files/Pods-ConfigExample/Pods-ConfigExample.release.xcconfig"; sourceTree = "<group>"; };
+		3F08EE6F257D5B900068360A /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		49CEDA70E7583B8DAE18D797 /* Pods_ConfigExample_ConfigExampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ConfigExample_ConfigExampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		783B9EFB55BC330A782EB183 /* Pods-ConfigExample-ConfigExampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ConfigExample-ConfigExampleUITests.release.xcconfig"; path = "Target Support Files/Pods-ConfigExample-ConfigExampleUITests/Pods-ConfigExample-ConfigExampleUITests.release.xcconfig"; sourceTree = "<group>"; };
+		D0168DDBDC49CD968F70D230 /* Pods-ConfigExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ConfigExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-ConfigExampleTests/Pods-ConfigExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		DA37B4CE9E6DE38A71557824 /* Pods-ConfigExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ConfigExample.debug.xcconfig"; path = "Target Support Files/Pods-ConfigExample/Pods-ConfigExample.debug.xcconfig"; sourceTree = "<group>"; };
+		E8452FC76371B8672A9379FD /* Pods_ConfigExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ConfigExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA062D5F24A13966006714D3 /* RemoteConfigView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigView.swift; sourceTree = "<group>"; };
 		EA20B4862497CC9D00B5E581 /* ConfigExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ConfigExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA20B4892497CC9D00B5E581 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -57,6 +69,8 @@
 		EA20B4BB2499191700B5E581 /* sugar_cookies.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = sugar_cookies.json; sourceTree = "<group>"; };
 		EA20B4C4249959E300B5E581 /* peanut_butter_and_jelly.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = peanut_butter_and_jelly.json; sourceTree = "<group>"; };
 		EABC75EA24AA185900D53A19 /* RemoteConfigDefaults.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = RemoteConfigDefaults.plist; sourceTree = "<group>"; };
+		F530E51838771B319755C12F /* Pods-ConfigExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ConfigExampleTests.release.xcconfig"; path = "Target Support Files/Pods-ConfigExampleTests/Pods-ConfigExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		F931F6109A7F60EDB23FD772 /* Pods-ConfigExample-ConfigExampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ConfigExample-ConfigExampleUITests.debug.xcconfig"; path = "Target Support Files/Pods-ConfigExample-ConfigExampleUITests/Pods-ConfigExample-ConfigExampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,6 +78,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D460E27621DA582FC06DEA59 /* Pods_ConfigExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -71,6 +86,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				344D9591B717041661383210 /* Pods_ConfigExampleTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,12 +94,23 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				00312B4FEE2D84BAFB635620 /* Pods_ConfigExample_ConfigExampleUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7BB2244744479B9BC0ED3AA7 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				11AA92BE67A2FBCE7AD24302 /* Pods_ConfigExample.framework */,
+				49CEDA70E7583B8DAE18D797 /* Pods_ConfigExample_ConfigExampleUITests.framework */,
+				E8452FC76371B8672A9379FD /* Pods_ConfigExampleTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		EA062D5E24A135EC006714D3 /* JSON Recipes */ = {
 			isa = PBXGroup;
 			children = (
@@ -97,10 +124,13 @@
 		EA20B47D2497CC9D00B5E581 = {
 			isa = PBXGroup;
 			children = (
+				3F08EE6F257D5B900068360A /* GoogleService-Info.plist */,
 				EA20B4882497CC9D00B5E581 /* ConfigExample */,
 				EA20B49F2497CC9F00B5E581 /* ConfigExampleTests */,
 				EA20B4AA2497CC9F00B5E581 /* ConfigExampleUITests */,
 				EA20B4872497CC9D00B5E581 /* Products */,
+				F7E2DF9E70EC4DEF227CB806 /* Pods */,
+				7BB2244744479B9BC0ED3AA7 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -148,6 +178,19 @@
 			path = ConfigExampleUITests;
 			sourceTree = "<group>";
 		};
+		F7E2DF9E70EC4DEF227CB806 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				DA37B4CE9E6DE38A71557824 /* Pods-ConfigExample.debug.xcconfig */,
+				2EB24F18CE92E7D4CBFDEE3C /* Pods-ConfigExample.release.xcconfig */,
+				F931F6109A7F60EDB23FD772 /* Pods-ConfigExample-ConfigExampleUITests.debug.xcconfig */,
+				783B9EFB55BC330A782EB183 /* Pods-ConfigExample-ConfigExampleUITests.release.xcconfig */,
+				D0168DDBDC49CD968F70D230 /* Pods-ConfigExampleTests.debug.xcconfig */,
+				F530E51838771B319755C12F /* Pods-ConfigExampleTests.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -155,9 +198,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EA20B4B02497CC9F00B5E581 /* Build configuration list for PBXNativeTarget "ConfigExample" */;
 			buildPhases = (
+				220E395260CE48AE228B5C66 /* [CP] Check Pods Manifest.lock */,
 				EA20B4822497CC9D00B5E581 /* Sources */,
 				EA20B4832497CC9D00B5E581 /* Frameworks */,
 				EA20B4842497CC9D00B5E581 /* Resources */,
+				93C0D586CD08FBF67C1B4912 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -172,6 +217,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EA20B4B32497CC9F00B5E581 /* Build configuration list for PBXNativeTarget "ConfigExampleTests" */;
 			buildPhases = (
+				0D9FF80E4A19D92E0A76A035 /* [CP] Check Pods Manifest.lock */,
 				EA20B4982497CC9F00B5E581 /* Sources */,
 				EA20B4992497CC9F00B5E581 /* Frameworks */,
 				EA20B49A2497CC9F00B5E581 /* Resources */,
@@ -190,9 +236,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EA20B4B62497CC9F00B5E581 /* Build configuration list for PBXNativeTarget "ConfigExampleUITests" */;
 			buildPhases = (
+				E8389FCFF03FA766A156DB1F /* [CP] Check Pods Manifest.lock */,
 				EA20B4A32497CC9F00B5E581 /* Sources */,
 				EA20B4A42497CC9F00B5E581 /* Frameworks */,
 				EA20B4A52497CC9F00B5E581 /* Resources */,
+				3DD886C4ABED485334393D95 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -258,6 +306,7 @@
 				EA20B4932497CC9F00B5E581 /* Assets.xcassets in Resources */,
 				EA20B4BA249918F900B5E581 /* salad.json in Resources */,
 				EA20B4C5249959E300B5E581 /* peanut_butter_and_jelly.json in Resources */,
+				3F08EE70257D5B900068360A /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -276,6 +325,109 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		0D9FF80E4A19D92E0A76A035 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ConfigExampleTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		220E395260CE48AE228B5C66 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ConfigExample-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3DD886C4ABED485334393D95 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ConfigExample-ConfigExampleUITests/Pods-ConfigExample-ConfigExampleUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ConfigExample-ConfigExampleUITests/Pods-ConfigExample-ConfigExampleUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ConfigExample-ConfigExampleUITests/Pods-ConfigExample-ConfigExampleUITests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		93C0D586CD08FBF67C1B4912 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ConfigExample/Pods-ConfigExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ConfigExample/Pods-ConfigExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ConfigExample/Pods-ConfigExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E8389FCFF03FA766A156DB1F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ConfigExample-ConfigExampleUITests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		EA20B4822497CC9D00B5E581 /* Sources */ = {
@@ -448,6 +600,7 @@
 		};
 		EA20B4B12497CC9F00B5E581 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = DA37B4CE9E6DE38A71557824 /* Pods-ConfigExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -467,6 +620,7 @@
 		};
 		EA20B4B22497CC9F00B5E581 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2EB24F18CE92E7D4CBFDEE3C /* Pods-ConfigExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -486,6 +640,7 @@
 		};
 		EA20B4B42497CC9F00B5E581 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = D0168DDBDC49CD968F70D230 /* Pods-ConfigExampleTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -508,6 +663,7 @@
 		};
 		EA20B4B52497CC9F00B5E581 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F530E51838771B319755C12F /* Pods-ConfigExampleTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -530,6 +686,7 @@
 		};
 		EA20B4B72497CC9F00B5E581 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F931F6109A7F60EDB23FD772 /* Pods-ConfigExample-ConfigExampleUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -550,6 +707,7 @@
 		};
 		EA20B4B82497CC9F00B5E581 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 783B9EFB55BC330A782EB183 /* Pods-ConfigExample-ConfigExampleUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/config/ConfigExample/RemoteConfigDefaults.plist
+++ b/config/ConfigExample/RemoteConfigDefaults.plist
@@ -6,5 +6,7 @@
         <string>Hi, I'm a label</string>
         <key>bottomLabelKey</key>
         <string>Today only, buy one get one free!</string>
+        <key>unsupported</key>
+        <false/>
     </dict>
 </plist>


### PR DESCRIPTION
**Setup:**
1. In the firebase dashboard, create a user property called AppVersion
2. In remote config, have the following parameter defined:
* Name: unsupported
  * Condition: User Property AppVersion contains regex ^2\.1\. -> true
  * default -> false
  
**Issue:** 
Setting the User Property to "2.10.0.0" in the application, returns true for unsupported on fetch even though the regex does not match. true should only be returned for "2.1.(anything)". The period is not being respected. The regex is valid RE2.