### PR TITLE
Temporarily disable flaky firestore/testApplyFilter test

### DIFF
--- a/firestore/FirestoreExampleUITests/FirestoreUITest.m
+++ b/firestore/FirestoreExampleUITests/FirestoreUITest.m
@@ -90,7 +90,8 @@ static NSString *const testPassword = @"Test123";
   [self checkMainScreenIsDisplayed];
 }
 
-- (void)testApplyFilter {
+// TODO(b/147740878): reenable this test once we've figured out how to make it deterministic
+- (void)xtestApplyFilter {
   // Navigate to the filter screen.
   [_app.buttons[@"Filter"] tap];
 


### PR DESCRIPTION
The testApplyFilter test assumes that there are a fixed number of
restaurants with the category Deli, and verifies that applying a filter
returns the right number of restaurants.

Unfortunately, the actual data behind this is random, and depends
entirely on the current state of the data in a shared project. If anyone
adds additional restaurants it's possible to add/remove Delis because
the client only loads the first 50 restaurants.

Tracked in b/147740878.