### PR TITLE
Update Crashlytics run script to handle zip installs

### DIFF
--- a/crashlytics/CrashlyticsExample.xcodeproj/project.pbxproj
+++ b/crashlytics/CrashlyticsExample.xcodeproj/project.pbxproj
@@ -413,7 +413,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/FirebaseCrashlytics/run\"\n";
+			shellScript = "\n# If installed via CocoaPods, then the \"run\" script will exist there\nif test -f \"${PODS_ROOT}/FirebaseCrashlytics/run\"; then\n  \"${PODS_ROOT}/FirebaseCrashlytics/run\"\n\n# If just the contents of the \"FirebaseCrashlytics\" folder from the\n# zip download was dragged into the Xcode project, check the project root\nelif test -f \"${PROJECT_DIR}/run\"; then\n  \"${PROJECT_DIR}/run\"\n  \n# If the whole \"FirebaseCrashlytics\" folder was dragged in from the\n# zip download, check for it in the root of the project \nelif test -f \"${PROJECT_DIR}/FirebaseCrashlytics/run\"; then\n  \"${PROJECT_DIR}/FirebaseCrashlytics/run\"\n  \n# If we can't find the run script, fail the build so that we\n# know to fix the issue\nelse\n  echo 'error: Could not find path to Crashlytics \"run\" script. Please ensure you have included the Crashlytics \"run\" script in the Xcode project directory, or update the path to the script in the Xcode project \"Build Phases\" > \"Run Script\"'\n  exit 1\nfi\n";
 		};
 		10E114DB20E3DDF00013E4A4 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
We had an issue where manual testers couldn't figure out why there was a build error here (following this [README](https://github.com/firebase/firebase-ios-sdk/blob/master/ZipBuilder/Template/README.md)). The reason was that the run script in the quick start is configured to look for the cocoapods path. Hopefully this change will make integrating via zip install easier.

Here's the content in human-readable form:

```
# If installed via CocoaPods, then the "run" script will exist there
if test -f "${PODS_ROOT}/FirebaseCrashlytics/run"; then
  "${PODS_ROOT}/FirebaseCrashlytics/run"

# If just the contents of the "FirebaseCrashlytics" folder from the
# zip download was dragged into the Xcode project, check the project root
elif test -f "${PROJECT_DIR}/run"; then
  "${PROJECT_DIR}/run"
  
# If the whole "FirebaseCrashlytics" folder was dragged in from the
# zip download, check for it in the root of the project 
elif test -f "${PROJECT_DIR}/FirebaseCrashlytics/run"; then
  "${PROJECT_DIR}/FirebaseCrashlytics/run"
  
# If we can't find the run script, fail the build so that we
# know to fix the issue
else
  echo 'error: Could not find path to Crashlytics "run" script. Please ensure you have included the Crashlytics "run" script in the Xcode project directory, or update the path to the script in the Xcode project "Build Phases" > "Run Script"'
  exit 1
fi
```