### PR TITLE
Tap to hide keyboard before tapping next

### DIFF
--- a/TestUtils/FIREGSignInHelper.m
+++ b/TestUtils/FIREGSignInHelper.m
@@ -48,7 +48,7 @@ void doGoogleSignIn(XCUIApplication *app, BOOL correctPassword, BOOL withAlert) 
   [login typeText:testAccount];
 
   // This is to hide keyboards after testAccount filled in.
-	[app tap];
+  [app tap];
   FIRWaitForVisible(webView.buttons[nextButton]);
   [webView.buttons[nextButton] tap];
 
@@ -57,7 +57,7 @@ void doGoogleSignIn(XCUIApplication *app, BOOL correctPassword, BOOL withAlert) 
   FIRWaitForVisible(password);
   [password tap];
   [password typeText:testPassword];
-	[app tap]
+  [app tap]
   [webView.buttons[nextButton] tap];
 
   // It could take some time to do authentication.

--- a/TestUtils/FIREGSignInHelper.m
+++ b/TestUtils/FIREGSignInHelper.m
@@ -47,6 +47,8 @@ void doGoogleSignIn(XCUIApplication *app, BOOL correctPassword, BOOL withAlert) 
   FIRWaitForVisible(app.keyboards.firstMatch);
   [login typeText:testAccount];
 
+  // This is to hide keyboards after testAccount filled in.
+	[app tap];
   FIRWaitForVisible(webView.buttons[nextButton]);
   [webView.buttons[nextButton] tap];
 
@@ -55,6 +57,7 @@ void doGoogleSignIn(XCUIApplication *app, BOOL correctPassword, BOOL withAlert) 
   FIRWaitForVisible(password);
   [password tap];
   [password typeText:testPassword];
+	[app tap]
   [webView.buttons[nextButton] tap];
 
   // It could take some time to do authentication.


### PR DESCRIPTION
UITests which do not activate a real keyboard will display a keyboard interface on the screen and this tap in app can hide the keyboard and do the rest. Otherwise, the Click Next will only hide the keyboard but not really click the next button and fails the test