### PR TITLE
Remove deprecated mcs code

### DIFF
--- a/messaging/MessagingExample/AppDelegate.m
+++ b/messaging/MessagingExample/AppDelegate.m
@@ -156,14 +156,6 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
 }
 // [END refresh_token]
 
-// [START ios_10_data_message]
-// Receive data messages on iOS 10+ directly from FCM (bypassing APNs) when the app is in the foreground.
-// To enable direct data messages, you can set [Messaging messaging].shouldEstablishDirectChannel to YES.
-- (void)messaging:(FIRMessaging *)messaging didReceiveMessage:(FIRMessagingRemoteMessage *)remoteMessage {
-  NSLog(@"Received data message: %@", remoteMessage.appData);
-}
-// [END ios_10_data_message]
-
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
   NSLog(@"Unable to register for remote notifications: %@", error);
 }

--- a/messaging/MessagingExample/AppDelegate.m
+++ b/messaging/MessagingExample/AppDelegate.m
@@ -124,7 +124,7 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
   NSLog(@"%@", userInfo);
 
   // Change this to your preferred presentation option
-  completionHandler(UNNotificationPresentationOptionNone);
+  completionHandler(UNNotificationPresentationOptionBadge | UNNotificationPresentationOptionAlert);
 }
 
 // Handle notification messages after display notification is tapped by the user.

--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -134,7 +134,7 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
     print(userInfo)
 
     // Change this to your preferred presentation option
-    completionHandler([])
+    completionHandler([[.alert, .sound]])
   }
 
   func userNotificationCenter(_ center: UNUserNotificationCenter,
@@ -166,13 +166,5 @@ extension AppDelegate : MessagingDelegate {
     // Note: This callback is fired at each app startup and whenever a new token is generated.
   }
   // [END refresh_token]
-
-  // [START ios_10_data_message]
-  // Receive data messages on iOS 10+ directly from FCM (bypassing APNs) when the app is in the foreground.
-  // To enable direct data messages, you can set Messaging.messaging().shouldEstablishDirectChannel to true.
-  func messaging(_ messaging: Messaging, didReceive remoteMessage: MessagingRemoteMessage) {
-    print("Received data message: \(remoteMessage.appData)")
-  }
-  // [END ios_10_data_message]
 }
 


### PR DESCRIPTION
Fix #932 

Also return alert type in one of the display notification delegate to ensure notification can be displayed when app is in foreground. This might or might not be the reason of [#5519](https://github.com/firebase/firebase-ios-sdk/issues/5519) where users can't receive notification.
