### PR TITLE
Auth UIKit type not found

### DIFF
--- a/authentication/AuthenticationExampleSwift/PasswordlessViewController.swift
+++ b/authentication/AuthenticationExampleSwift/PasswordlessViewController.swift
@@ -15,6 +15,7 @@
 //
 
 import Firebase
+import UIKit
 
 @objc(PasswordlessViewController)
 class PasswordlessViewController: UIViewController {


### PR DESCRIPTION
In Framework testing, the UI type variables are not found.
https://github.com/firebase/firebase-ios-sdk/pull/5929/checks?check_run_id=812209394