### PR TITLE
Update Add Framework script

### DIFF
--- a/scripts/add_framework_script.rb
+++ b/scripts/add_framework_script.rb
@@ -16,26 +16,55 @@
 
 require 'xcodeproj'
 require 'set'
-sdk = ARGV[0]
-target = ARGV[1]
-framework_dir = ARGV[2]
+require 'optparse'
+
+options = {}
+options[:source_tree] = "SOURCE_ROOT"
+OptionParser.new do |opt|
+  opt.on('--sdk SDK') { |o| options[:sdk] = o }
+  opt.on('--target TARGET') { |o| options[:target] = o }
+  opt.on('--framework_path FRAMEWORK_PATH') { |o| options[:framework_path] = o }
+  opt.on('--source_tree SOURCE_TREE') { |o| options[:source_tree] = o }
+end.parse!
+sdk = options[:sdk]
+target = options[:target]
+framework_path = options[:framework_path]
+source_tree = options[:source_tree]
 project_path = "#{sdk}Example.xcodeproj"
 project = Xcodeproj::Project.open(project_path)
-framework_group = Dir.glob(File.join(framework_dir ,"*{framework,dylib}"))
+project_framework_group = project.frameworks_group
 
-project.targets.each do |project_target|
-  next unless project_target.name == target
-  project_framework_group = project.frameworks_group
-  framework_build_phase = project_target.frameworks_build_phase
-  framework_set = project_target.frameworks_build_phase.files.to_set
-	puts "The following frameworks are added to #{project_target}"
-  framework_group.each do |framework|
-    next if framework_set.size == framework_set.add(framework).size
-    ref = project_framework_group.new_reference("#{framework}")
-    ref.name = "#{File.basename(framework)}"
-    ref.source_tree = "SOURCE_ROOT"
-    framework_build_phase.add_file_reference(ref)
-    puts ref
+def add_ref(framework_group, framework, source_tree, framework_build_phase)
+  ref = framework_group.new_reference("#{framework}")
+  ref.name = "#{File.basename(framework)}"
+  ref.source_tree = source_tree
+  framework_build_phase.add_file_reference(ref)
+  puts ref
+end
+
+if File.directory?(framework_path)
+  framework_group = Dir.glob(File.join(framework_path, "*{framework,dylib}"))
+
+  project.targets.each do |project_target|
+    next unless project_target.name == target
+    framework_set = project_target.frameworks_build_phase.files.to_set
+    puts "The following frameworks are added to #{project_target}"
+    framework_group.each do |framework|
+      next if framework_set.size == framework_set.add(framework).size
+      add_ref(project_framework_group,
+              framework,
+              source_tree,
+              project_target.frameworks_build_phase)
+    end
+  end
+else
+  project.targets.each do |project_target|
+    next unless project_target.name == target
+    puts "The following file is added to #{project_target}"
+    add_ref(project_framework_group,
+            framework_path,
+            source_tree,
+            project_target.frameworks_build_phase)
   end
 end
 project.save()


### PR DESCRIPTION
Auth testapp request libc++.dylib from /usr/lib and accelerate.framework from xcode frameworks dir. These two cannot be copied to another folder and imported to the xcode project. This update will enable this tool to import a single file.
The argument/options update will increase the readability.
The test is done for [remote config in firebase-ios-sdk framework testing workflow](https://github.com/firebase/firebase-ios-sdk/runs/828632641?check_suite_focus=true)

scripts/setup_quickstart_framework.sh from firebase-ios-sdk repo depends on this file and will be updated whlie this pr is submitted. The change for the tested pr is [here](https://github.com/firebase/firebase-ios-sdk/pull/5958/files).