### PR TITLE
Fix missing messaging call in swizzling disabled snippets

### DIFF
--- a/messaging/MessagingExample/AppDelegate.m
+++ b/messaging/MessagingExample/AppDelegate.m
@@ -136,6 +136,9 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
     NSLog(@"Message ID: %@", userInfo[kGCMMessageIDKey]);
   }
 
+  // With swizzling disabled you must let Messaging know about the message, for Analytics
+  // [[FIRMessaging messaging] appDidReceiveMessage:userInfo];
+
   // Print full message.
   NSLog(@"%@", userInfo);
 

--- a/messaging/MessagingExampleSwift/AppDelegate.swift
+++ b/messaging/MessagingExampleSwift/AppDelegate.swift
@@ -146,6 +146,9 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
       print("Message ID: \(messageID)")
     }
 
+    // With swizzling disabled you must let Messaging know about the message, for Analytics
+    // Messaging.messaging().appDidReceiveMessage(userInfo)
+
     // Print full message.
     print(userInfo)
 


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-ios-sdk/issues/5625.