### PR TITLE
Fixing Deeplink popup not coming when clicking an FDL 

### DIFF
--- a/dynamiclinks/DynamicLinksExampleSwift/AppDelegate.swift
+++ b/dynamiclinks/DynamicLinksExampleSwift/AppDelegate.swift
@@ -68,8 +68,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
     let handled = DynamicLinks.dynamicLinks().handleUniversalLink(userActivity.webpageURL!) { (dynamiclink, error) in
       // [START_EXCLUDE]
-      if((dynamiclink) != nil){
-        self.handleDynamicLink(dynamiclink!)
+      if let dynamiclink = dynamiclink {
+        self.handleDynamicLink(dynamiclink)
       }
       // [END_EXCLUDE]
     }

--- a/dynamiclinks/DynamicLinksExampleSwift/AppDelegate.swift
+++ b/dynamiclinks/DynamicLinksExampleSwift/AppDelegate.swift
@@ -68,8 +68,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
     let handled = DynamicLinks.dynamicLinks().handleUniversalLink(userActivity.webpageURL!) { (dynamiclink, error) in
       // [START_EXCLUDE]
-
-    // [END_EXCLUDE]
+      if((dynamiclink) != nil){
+        self.handleDynamicLink(dynamiclink!)
+      }
+      // [END_EXCLUDE]
     }
 
     // [START_EXCLUDE silent]


### PR DESCRIPTION
Fixing Deeplink popup not coming when clicking an FDL and opening up the app using universal linking.

Code was not in place to handle and show the pop up when the app gets universal linked by clicking on an fdl.

-Added code to show the Deeplink pop up message when clicking an FDL and opening up the app using universal linking.