### PR TITLE
Change API key in mock-GoogleService-Info.plist to match valid format

### DIFF
--- a/mock-GoogleService-Info.plist
+++ b/mock-GoogleService-Info.plist
@@ -7,7 +7,7 @@
 	<key>AD_UNIT_ID_FOR_INTERSTITIAL_TEST</key>
 	<string>ca-app-pub-3940256099942544/4411468910</string>
 	<key>API_KEY</key>
-	<string>AIzaSyAzlj4APqi5S58nFtE52Da-fYBOHA2MhaY</string>
+	<string>AIzaSyAzlj4APqi5S58nFtE52Da0fYBOHA2MhaY</string>
 	<key>BUNDLE_ID</key>
 	<string>id</string>
 	<key>CLIENT_ID</key>


### PR DESCRIPTION
Required to fix tests for https://github.com/firebase/firebase-ios-sdk/pull/6678