### PR TITLE
Disable Storage UI Tests until they're updated for Xcode 12

### DIFF
--- a/storage/StorageExampleUITests/StorageExampleUITests.m
+++ b/storage/StorageExampleUITests/StorageExampleUITests.m
@@ -58,7 +58,7 @@ static NSString *const uploadStartedTrait = @"Beginning upload";
   [super tearDown];
 }
 
-- (void)testNavigateToDownloadViewAndBack_simulator {
+- (void)SKIP_testNavigateToDownloadViewAndBack_simulator {
   // Verify that Storage Example app launched successfully and its title is visible.
   [self checkHeaderIsPresent:header];
 
@@ -75,7 +75,8 @@ static NSString *const uploadStartedTrait = @"Beginning upload";
   [self checkHeaderIsPresent:header];
 }
 
-- (void)testUploadFromPhotoLibraryAndDownload_simulator {
+// The Photos UI changed in Xcode 12 and this function needs to be updated.
+- (void)SKIP_testUploadFromPhotoLibraryAndDownload_simulator {
   // Try to select an existing image.
   [self selectImageFromLibrary];
 


### PR DESCRIPTION
The Photos UI has changed in the Xcode 12 simulators breaking the UI tests.

This PR disables the tests until a fix is made.

The Functions CI failure is addressed in #1072

Issue to reenable at #1073