### PR TITLE
Skip Functions UITests until updated for Xcode 12

### DIFF
--- a/functions/FunctionsExampleUITests/FunctionsExampleUITests.m
+++ b/functions/FunctionsExampleUITests/FunctionsExampleUITests.m
@@ -57,13 +57,13 @@ static NSString *const welcomeMessage = @"HTTPS Callable functions Quickstart";
   [super tearDown];
 }
 
-- (void)testVerifyAppLaunched {
+- (void)SKIPtestVerifyAppLaunched {
   // Check that main UI elements are present on the screen.
   XCTAssertTrue([[_app staticTexts][@"Add two numbers"] exists]);
   XCTAssertTrue([[_app staticTexts][@"Sanitize a message"] exists]);
 }
 
-- (void)testAddTwoNumbers {
+- (void)SKIPtestAddTwoNumbers {
   XCUIElement* number1 = [_app textFields][@"Num 1"];
   FIRWaitForVisible(number1);
   [number1 tap];
@@ -82,7 +82,7 @@ static NSString *const welcomeMessage = @"HTTPS Callable functions Quickstart";
   XCTAssert(result.exists);
 }
 
-- (void)testChangeMessage {
+- (void)SKIPtestChangeMessage {
   NSString* testText = @"hello from cloud functions!";
   XCUIElement* input = [_app textFields][@"Add your message"];
   [input tap];


### PR DESCRIPTION
The extra validation introduced in Xcode 12 and iOS 14 breaks the sign in flow in the Functions test.

Disabling here until it can be reworked.

Issue to reenable at #1074