### PR TITLE
docs(functions): fix README's StackOverflow link

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -21,7 +21,7 @@ Getting Started
 Support
 -------
 
-- [Stack Overflow](https://stackoverflow.com/questions/tagged/firebase-crash-reporting)
+- [Stack Overflow](https://stackoverflow.com/questions/tagged/google-cloud-functions)
 - [Firebase Support](https://firebase.google.com/support/)
 
 License


### PR DESCRIPTION
The StackOverlow link in the functions quickstart's README file was mistakenly pointing to Firebase Crash Reporting. This PR should point it to the correct url.