### PR TITLE
Explicitly initialize Facebook SDK.

### DIFF
--- a/authentication/AuthenticationExample/AppDelegate.swift
+++ b/authentication/AuthenticationExample/AppDelegate.swift
@@ -14,6 +14,7 @@
 
 import UIKit
 import Firebase
+import FBSDKCoreKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -24,7 +25,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     FirebaseApp.configure()
 
+    ApplicationDelegate.shared.application(
+        application,
+        didFinishLaunchingWithOptions: launchOptions
+    )
+
     return true
+  }
+
+  func application(
+      _ app: UIApplication,
+      open url: URL,
+      options: [UIApplication.OpenURLOptionsKey : Any] = [:]
+  ) -> Bool {
+      ApplicationDelegate.shared.application(
+          app,
+          open: url,
+          sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String,
+          annotation: options[UIApplication.OpenURLOptionsKey.annotation]
+      )
   }
 
   // MARK: UISceneSession Lifecycle


### PR DESCRIPTION
Follow the steps in https://developers.facebook.com/docs/facebook-login/ios#delegate to initialize the `FBSDKCoreKit` SDK.

Previously, Facebook Login worked without this, but in `FBSDKCoreKit` v9.2.0 and later, it seems that the Facebook SDK needs to be explicitly initialized in order to properly access the values in `Info.plist`.