### PR TITLE
Add abtesting installation auth token usage

### DIFF
--- a/abtesting/ABTestingExample/ViewController.swift
+++ b/abtesting/ABTestingExample/ViewController.swift
@@ -62,6 +62,14 @@ class ViewController: UIViewController, UITableViewDataSource {
 
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
+    Installations.installations().authTokenForcingRefresh(true) { (token, error) in
+      if let error = error {
+        print("Error fetching token: \(error)")
+        return
+      }
+      guard let token = token else { return }
+      print("Installation auth token: \(token.authToken)")
+    }
     RemoteConfig.remoteConfig().fetch(withExpirationDuration: 0) { (status, error) in
       if let error = error {
         print("Error fetching config: \(error)")

--- a/abtesting/README.md
+++ b/abtesting/README.md
@@ -16,7 +16,7 @@ its value in 'Variant A' to `dark`. In the third step, select any goal metric.
 Verify the following two flows:
 
 Test on device: 
-Run the sample and copy the printed Instance ID token from Xcode's console
+Run the sample and copy the printed remote installations ID or the installation auth token from Xcode's console
 into the 'Manage test devices' section in Firebase Console (click into details
 in 'Experiment Overview' when experiment is in Draft status).
 


### PR DESCRIPTION
Add installation auth token logging to abtesting quickstart sample and accompanying instructions.