### PR TITLE
Add async/await functionality to abtesting [SwiftUI]

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -54,6 +54,7 @@ jobs:
           -scheme 'ABTestingExample (iOS)' \
           -sdk iphonesimulator \
           -destination 'platform=iOS Simulator,name=iPhone 11' \
+          build \
           test \
           | xcpretty
         env:

--- a/abtesting/Shared/AppConfig.swift
+++ b/abtesting/Shared/AppConfig.swift
@@ -57,6 +57,31 @@ class AppConfig: ObservableObject {
     }
   }
 
+  @available(iOS 15, *)
+  func updateFromRemoteConfigAsync() async {
+    let remoteConfig = RemoteConfig.remoteConfig()
+    do {
+      let status = try await remoteConfig.fetch(withExpirationDuration: 0)
+      print("Config fetch completed with status: \(status.debugDescription)")
+      do {
+        let changed = try await remoteConfig.activate()
+        let value = remoteConfig["color_scheme"].stringValue ?? "nil"
+        if changed {
+          print("Remote Config changed to: \(value)")
+          DispatchQueue.main.async {
+            self.colorScheme = ColorScheme(value)
+          }
+        } else {
+          print("Remote Config did not change from: \(value)")
+        }
+      } catch {
+        print("Error activating config: \(error)")
+      }
+    } catch {
+      print("Error fetching config: \(error)")
+    }
+  }
+
   @objc func printInstallationAuthToken() {
     Installations.installations().authTokenForcingRefresh(true) { token, error in
       if let error = error {

--- a/abtesting/Shared/AppConfig.swift
+++ b/abtesting/Shared/AppConfig.swift
@@ -57,30 +57,32 @@ class AppConfig: ObservableObject {
     }
   }
 
-  @available(iOS 15, *)
-  func updateFromRemoteConfigAsync() async {
-    let remoteConfig = RemoteConfig.remoteConfig()
-    do {
-      let status = try await remoteConfig.fetch(withExpirationDuration: 0)
-      print("Config fetch completed with status: \(status.debugDescription)")
+  #if swift(>=5.5)
+    @available(iOS 15, *)
+    func updateFromRemoteConfigAsync() async {
+      let remoteConfig = RemoteConfig.remoteConfig()
       do {
-        let changed = try await remoteConfig.activate()
-        let value = remoteConfig["color_scheme"].stringValue ?? "nil"
-        if changed {
-          print("Remote Config changed to: \(value)")
-          DispatchQueue.main.async {
-            self.colorScheme = ColorScheme(value)
+        let status = try await remoteConfig.fetch(withExpirationDuration: 0)
+        print("Config fetch completed with status: \(status.debugDescription)")
+        do {
+          let changed = try await remoteConfig.activate()
+          let value = remoteConfig["color_scheme"].stringValue ?? "nil"
+          if changed {
+            print("Remote Config changed to: \(value)")
+            DispatchQueue.main.async {
+              self.colorScheme = ColorScheme(value)
+            }
+          } else {
+            print("Remote Config did not change from: \(value)")
           }
-        } else {
-          print("Remote Config did not change from: \(value)")
+        } catch {
+          print("Error activating config: \(error)")
         }
       } catch {
-        print("Error activating config: \(error)")
+        print("Error fetching config: \(error)")
       }
-    } catch {
-      print("Error fetching config: \(error)")
     }
-  }
+  #endif
 
   @objc func printInstallationAuthToken() {
     Installations.installations().authTokenForcingRefresh(true) { token, error in

--- a/abtesting/Shared/ContentView.swift
+++ b/abtesting/Shared/ContentView.swift
@@ -29,11 +29,15 @@ struct ContentView: View {
   var body: some View {
     NavigationView {
       VStack {
-        if #available(iOS 15, *) {
-          BasicList(data: data).refreshable {
-            await appConfig.updateFromRemoteConfigAsync()
-          }
-        } else { BasicList(data: data) }
+        #if swift(>=5.5)
+          if #available(iOS 15, *) {
+            BasicList(data: data).refreshable {
+              await appConfig.updateFromRemoteConfigAsync()
+            }
+          } else { BasicList(data: data) }
+        #else
+          BasicList(data: data)
+        #endif
         Button("Refresh") { appConfig.updateFromRemoteConfig() }
         Spacer()
       }

--- a/abtesting/Shared/ContentView.swift
+++ b/abtesting/Shared/ContentView.swift
@@ -31,7 +31,7 @@ struct ContentView: View {
       VStack {
         if #available(iOS 15, *) {
           BasicList(data: data).refreshable {
-            appConfig.updateFromRemoteConfig()
+            await appConfig.updateFromRemoteConfigAsync()
           }
         } else { BasicList(data: data) }
         Button("Refresh") { appConfig.updateFromRemoteConfig() }


### PR DESCRIPTION
Use updateFromRemoteConfigAsync when using iOS 15 pull-down-to-refresh functionality.

Where else should async/await functionality be used? Should the app log something special to showcase async/await?