### PR TITLE
FIAM: explicitly import modules used in Swift

### DIFF
--- a/inappmessaging/InAppMessagingExampleSwift/AppDelegate.swift
+++ b/inappmessaging/InAppMessagingExampleSwift/AppDelegate.swift
@@ -14,6 +14,8 @@
 //  limitations under the License.
 //
 
+import UIKit
+
 import Firebase
 
 @UIApplicationMain

--- a/inappmessaging/InAppMessagingExampleSwift/ViewController.swift
+++ b/inappmessaging/InAppMessagingExampleSwift/ViewController.swift
@@ -17,7 +17,6 @@
 import UIKit
 
 import Firebase
-import FirebaseAnalytics
 
 class ViewController: UIViewController {
   @IBOutlet var textField: UITextField!

--- a/inappmessaging/InAppMessagingExampleSwift/ViewController.swift
+++ b/inappmessaging/InAppMessagingExampleSwift/ViewController.swift
@@ -14,7 +14,10 @@
 //  limitations under the License.
 //
 
+import UIKit
+
 import Firebase
+import FirebaseAnalytics
 
 class ViewController: UIViewController {
   @IBOutlet var textField: UITextField!


### PR DESCRIPTION
Should fix the [failure](https://github.com/firebase/firebase-ios-sdk/runs/3251416541?check_suite_focus=true) from https://github.com/firebase/firebase-ios-sdk/issues/8471#issuecomment-893449537.