### PR TITLE
Update FIREGSignInInfo.h

### DIFF
--- a/TestUtils/FIREGSignInInfo.h
+++ b/TestUtils/FIREGSignInInfo.h
@@ -14,6 +14,5 @@
 //  limitations under the License.
 //
 
-#error Fill in #define values and delete this line
 #define TESTACCOUNT @"ACCOUNT HERE"
 #define TESTPASSWORD @"PASSWORD HERE"


### PR DESCRIPTION
I don't think the login info is even used in tests anymore. I have an experimental PR https://github.com/firebase/firebase-ios-sdk/pull/8644 that removes the `FIREGSignInInfo.h` secret from GHA. In this PR, Im removing an intentional build error so I can run the tests in #8644 and see if this file is important