### PR TITLE
Use common qs bundle ID format in Crashlytics qs

### DIFF
--- a/crashlytics/CrashlyticsExample.xcodeproj/project.pbxproj
+++ b/crashlytics/CrashlyticsExample.xcodeproj/project.pbxproj
@@ -1000,7 +1000,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "Google-LLC.CrashlyticsSwiftUIExample";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.google.firebase.quickstart.CrashlyticsExample";
 				PRODUCT_NAME = CrashlyticsSwiftUIExample;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -1035,7 +1035,7 @@
 				);
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "Google-LLC.CrashlyticsSwiftUIExample";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.google.firebase.quickstart.CrashlyticsExample";
 				PRODUCT_NAME = CrashlyticsSwiftUIExample;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -1071,7 +1071,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "Google-LLC.CrashlyticsSwiftUIExample";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.google.firebase.quickstart.CrashlyticsExample";
 				PRODUCT_NAME = CrashlyticsSwiftUIExample;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -1107,7 +1107,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "Google-LLC.CrashlyticsSwiftUIExample";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.google.firebase.quickstart.CrashlyticsExample";
 				PRODUCT_NAME = CrashlyticsSwiftUIExample;
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
@@ -1141,7 +1141,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "Google-LLC.CrashlyticsSwiftUIExample.watchkitapp";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.google.firebase.quickstart.CrashlyticsExample.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -1180,7 +1180,7 @@
 				);
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "Google-LLC.CrashlyticsSwiftUIExample.watchkitapp";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.google.firebase.quickstart.CrashlyticsExample.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -1215,7 +1215,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "Google-LLC.CrashlyticsSwiftUIExample.watchkitapp.watchkitextension";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.google.firebase.quickstart.CrashlyticsExample.watchkitapp.watchkitextension";
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -1252,7 +1252,7 @@
 				);
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "Google-LLC.CrashlyticsSwiftUIExample.watchkitapp.watchkitextension";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.google.firebase.quickstart.CrashlyticsExample.watchkitapp.watchkitextension";
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -1287,7 +1287,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "Google-LLC.CrashlyticsSwiftUIExample";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.google.firebase.quickstart.CrashlyticsExample";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -1323,7 +1323,7 @@
 				);
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "Google-LLC.CrashlyticsSwiftUIExample";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.google.firebase.quickstart.CrashlyticsExample";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;

--- a/crashlytics/CrashlyticsExample.xcodeproj/xcshareddata/xcschemes/CrashlyticsExample (watchOS) (Complication).xcscheme
+++ b/crashlytics/CrashlyticsExample.xcodeproj/xcshareddata/xcschemes/CrashlyticsExample (watchOS) (Complication).xcscheme
@@ -65,8 +65,10 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "32">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/CrashlyticsSwiftUIExample">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C74593FA26BDDD5F00153AE3"
@@ -74,7 +76,7 @@
             BlueprintName = "CrashlyticsSwiftUIExample_(watchOS)"
             ReferencedContainer = "container:CrashlyticsExample.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -83,8 +85,10 @@
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
       launchAutomaticallySubstyle = "32">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/CrashlyticsSwiftUIExample">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C74593FA26BDDD5F00153AE3"
@@ -92,7 +96,16 @@
             BlueprintName = "CrashlyticsSwiftUIExample_(watchOS)"
             ReferencedContainer = "container:CrashlyticsExample.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C74593FA26BDDD5F00153AE3"
+            BuildableName = "CrashlyticsSwiftUIExample_(watchOS).app"
+            BlueprintName = "CrashlyticsSwiftUIExample_(watchOS)"
+            ReferencedContainer = "container:CrashlyticsExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/crashlytics/CrashlyticsExample.xcodeproj/xcshareddata/xcschemes/CrashlyticsExample (watchOS) (Notification).xcscheme
+++ b/crashlytics/CrashlyticsExample.xcodeproj/xcshareddata/xcschemes/CrashlyticsExample (watchOS) (Notification).xcscheme
@@ -66,8 +66,10 @@
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "8"
       notificationPayloadFile = "CrashlyticsSwiftUIExample_(watchOS)_Extension/PushNotificationPayload.apns">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/CrashlyticsSwiftUIExample">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C74593FA26BDDD5F00153AE3"
@@ -75,7 +77,7 @@
             BlueprintName = "CrashlyticsSwiftUIExample_(watchOS)"
             ReferencedContainer = "container:CrashlyticsExample.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -85,8 +87,10 @@
       debugDocumentVersioning = "YES"
       launchAutomaticallySubstyle = "8"
       notificationPayloadFile = "CrashlyticsSwiftUIExample_(watchOS)_Extension/PushNotificationPayload.apns">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/CrashlyticsSwiftUIExample">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C74593FA26BDDD5F00153AE3"
@@ -94,7 +98,16 @@
             BlueprintName = "CrashlyticsSwiftUIExample_(watchOS)"
             ReferencedContainer = "container:CrashlyticsExample.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C74593FA26BDDD5F00153AE3"
+            BuildableName = "CrashlyticsSwiftUIExample_(watchOS).app"
+            BlueprintName = "CrashlyticsSwiftUIExample_(watchOS)"
+            ReferencedContainer = "container:CrashlyticsExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/crashlytics/CrashlyticsExample.xcodeproj/xcshareddata/xcschemes/CrashlyticsExample (watchOS).xcscheme
+++ b/crashlytics/CrashlyticsExample.xcodeproj/xcshareddata/xcschemes/CrashlyticsExample (watchOS).xcscheme
@@ -76,8 +76,10 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       notificationPayloadFile = "CrashlyticsSwiftUIExample_(watchOS)_Extension/PushNotificationPayload.apns">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/CrashlyticsSwiftUIExample">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C74593FA26BDDD5F00153AE3"
@@ -85,7 +87,7 @@
             BlueprintName = "CrashlyticsSwiftUIExample_(watchOS)"
             ReferencedContainer = "container:CrashlyticsExample.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -94,8 +96,10 @@
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
       notificationPayloadFile = "CrashlyticsSwiftUIExample_(watchOS)_Extension/PushNotificationPayload.apns">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/CrashlyticsSwiftUIExample">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C74593FA26BDDD5F00153AE3"
@@ -103,7 +107,16 @@
             BlueprintName = "CrashlyticsSwiftUIExample_(watchOS)"
             ReferencedContainer = "container:CrashlyticsExample.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C74593FA26BDDD5F00153AE3"
+            BuildableName = "CrashlyticsSwiftUIExample_(watchOS).app"
+            BlueprintName = "CrashlyticsSwiftUIExample_(watchOS)"
+            ReferencedContainer = "container:CrashlyticsExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/crashlytics/CrashlyticsSwiftUIExample_(watchOS)/Info.plist
+++ b/crashlytics/CrashlyticsSwiftUIExample_(watchOS)/Info.plist
@@ -26,7 +26,7 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>WKCompanionAppBundleIdentifier</key>
-	<string>Google-LLC.CrashlyticsSwiftUIExample</string>
+	<string>com.google.firebase.quickstart.CrashlyticsExample</string>
 	<key>WKWatchKitApp</key>
 	<true/>
 </dict>

--- a/crashlytics/CrashlyticsSwiftUIExample_(watchOS)_Extension/Info.plist
+++ b/crashlytics/CrashlyticsSwiftUIExample_(watchOS)_Extension/Info.plist
@@ -27,7 +27,7 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>WKAppBundleIdentifier</key>
-			<string>Google-LLC.CrashlyticsSwiftUIExample.watchkitapp</string>
+			<string>com.google.firebase.quickstart.CrashlyticsExample.watchkitapp</string>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.watchkit</string>

--- a/crashlytics/OUTLINE.md
+++ b/crashlytics/OUTLINE.md
@@ -41,9 +41,9 @@ code can be shared across those platforms.
 One exception is the omission of Reachability.swift on watchOS. Reachability.swift uses Apple’s
 System Configuration framework, which currently does not support watchOS. 
 
-This Quickstart Sample App’s Bundle Identifier is `Google-LLC.CrashlyticsSwiftUIExample` for iOS,
+This Quickstart Sample App’s Bundle Identifier is `com.google.firebase.quickstart.CrashlyticsExample` for iOS,
 macOS, and tvOS targets. But the Bundle Identifier for watchOS target is
-`Google-LLC.CrashlyticsSwiftUIExample.watchkitapp`. This means that to generate and view crash logs
+`com.google.firebase.quickstart.CrashlyticsExample.watchkitapp`. This means that to generate and view crash logs
 onto the Firebase console, a new app in Firebase with the full bundle ID will be needed. 
 
 ## File Structure


### PR DESCRIPTION
Was using crashlytics qs to debug an issue and got a warning that the bundle ID didnt match with that in the default googleservice-info.plist. 

I did this with: 
```
grep -rl 'Google-LLC.CrashlyticsSwiftUIExample' . | xargs sed -i '' 's/Google-LLC.CrashlyticsSwiftUIExample/com.google.firebase.quickstart.CrashlyticsExample/'
```