### PR TITLE
Stop using Firebase umbrella pod in Storage quickstart

### DIFF
--- a/storage/Podfile
+++ b/storage/Podfile
@@ -3,9 +3,8 @@
 use_frameworks!
 platform :ios, '10.0'
 
-pod 'Firebase/Analytics'
-pod 'Firebase/Auth'
-pod 'Firebase/Storage'
+pod 'FirebaseAuth'
+pod 'FirebaseStorage'
 
 target 'StorageExample' do
 end

--- a/storage/Podfile.lock
+++ b/storage/Podfile.lock
@@ -1,79 +1,23 @@
 PODS:
-  - Firebase/Analytics (8.9.1):
-    - Firebase/Core
-  - Firebase/Auth (8.9.1):
-    - Firebase/CoreOnly
-    - FirebaseAuth (~> 8.9.0)
-  - Firebase/Core (8.9.1):
-    - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 8.9.1)
-  - Firebase/CoreOnly (8.9.1):
-    - FirebaseCore (= 8.9.1)
-  - Firebase/Storage (8.9.1):
-    - Firebase/CoreOnly
-    - FirebaseStorage (~> 8.9.0)
-  - FirebaseAnalytics (8.9.1):
-    - FirebaseAnalytics/AdIdSupport (= 8.9.1)
-    - FirebaseCore (~> 8.0)
-    - FirebaseInstallations (~> 8.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
-    - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (8.9.1):
-    - FirebaseCore (~> 8.0)
-    - FirebaseInstallations (~> 8.0)
-    - GoogleAppMeasurement (= 8.9.1)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
-    - nanopb (~> 2.30908.0)
-  - FirebaseAuth (8.9.0):
+  - FirebaseAuth (8.10.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
     - GoogleUtilities/Environment (~> 7.6)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseCore (8.9.1):
+  - FirebaseCore (8.10.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.6)
     - GoogleUtilities/Logger (~> 7.6)
-  - FirebaseCoreDiagnostics (8.9.0):
+  - FirebaseCoreDiagnostics (8.10.0):
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/Environment (~> 7.6)
     - GoogleUtilities/Logger (~> 7.6)
     - nanopb (~> 2.30908.0)
-  - FirebaseInstallations (8.9.0):
-    - FirebaseCore (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.6)
-    - GoogleUtilities/UserDefaults (~> 7.6)
-    - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseStorage (8.9.0):
+  - FirebaseStorage (8.10.0):
     - FirebaseCore (~> 8.0)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseStorageSwift (8.9.0-beta):
+  - FirebaseStorageSwift (8.10.0-beta):
     - FirebaseStorage (~> 8.0)
-  - GoogleAppMeasurement (8.9.1):
-    - GoogleAppMeasurement/AdIdSupport (= 8.9.1)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
-    - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.9.1):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.9.1)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
-    - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (8.9.1):
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
-    - nanopb (~> 2.30908.0)
   - GoogleDataTransport (9.1.2):
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30908.0)
@@ -86,16 +30,12 @@ PODS:
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Logger (7.6.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.6.0):
-    - GoogleUtilities/Logger
   - GoogleUtilities/Network (7.6.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
   - "GoogleUtilities/NSData+zlib (7.6.0)"
   - GoogleUtilities/Reachability (7.6.0):
-    - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.6.0):
     - GoogleUtilities/Logger
   - GTMSessionFetcher/Core (1.7.0)
   - nanopb (2.30908.0):
@@ -106,22 +46,17 @@ PODS:
   - PromisesObjC (2.0.0)
 
 DEPENDENCIES:
-  - Firebase/Analytics
-  - Firebase/Auth
-  - Firebase/Storage
+  - FirebaseAuth
+  - FirebaseStorage
   - FirebaseStorageSwift (> 7.0-beta)
 
 SPEC REPOS:
   trunk:
-    - Firebase
-    - FirebaseAnalytics
     - FirebaseAuth
     - FirebaseCore
     - FirebaseCoreDiagnostics
-    - FirebaseInstallations
     - FirebaseStorage
     - FirebaseStorageSwift
-    - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleUtilities
     - GTMSessionFetcher
@@ -129,21 +64,17 @@ SPEC REPOS:
     - PromisesObjC
 
 SPEC CHECKSUMS:
-  Firebase: fb5114cd2bf96e2ff7bcb01d0d9a156cf5fd2f07
-  FirebaseAnalytics: 4ab446ce08a3fe52e8a4303dd997cf26276bf968
-  FirebaseAuth: 2b78b2a32c07b3ecfa4970bdf1d3632b8304099b
-  FirebaseCore: c5aab092d9c4b8efea894946166b04c9d9ef0e68
-  FirebaseCoreDiagnostics: 5daa63f1c1409d981a2d5007daa100b36eac6a34
-  FirebaseInstallations: caa7c8e0d3e2345b8829d2fa9ca1b4dfbf2fcc85
-  FirebaseStorage: 452c98c31ccb40b819764bf3039426c4388d9939
-  FirebaseStorageSwift: a806d20af0ec0b019e082e593649615f0bb978cd
-  GoogleAppMeasurement: 837649ad3987936c232f6717c5680216f6243d24
+  FirebaseAuth: 59a2d2b933b5b79e18fb1e6ad230c6abdaa73d26
+  FirebaseCore: 04186597c095da37d90ff9fd3e53bc61a1ff2440
+  FirebaseCoreDiagnostics: 56fb7216d87e0e6ec2feddefa9d8a392fe8b2c18
+  FirebaseStorage: 815410224b548172c578f02554a86bbc8f817f50
+  FirebaseStorageSwift: 79a8ad5538cd6de0d882d73250a9dbc8c8bf7da4
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleUtilities: 684ee790a24f73ebb2d1d966e9711c203f2a4237
   GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
 
-PODFILE CHECKSUM: 779e4adf5d334894b075beab24ee72af2adbf4b1
+PODFILE CHECKSUM: 3db2ca4b6dfea69e157a30db8e82a984077684ca
 
 COCOAPODS: 1.11.2

--- a/storage/StorageExample/AppDelegate.m
+++ b/storage/StorageExample/AppDelegate.m
@@ -15,7 +15,7 @@
 //
 
 #import "AppDelegate.h"
-@import Firebase;
+@import FirebaseCore;
 
 @implementation AppDelegate
 

--- a/storage/StorageExample/DownloadViewController.m
+++ b/storage/StorageExample/DownloadViewController.m
@@ -15,7 +15,7 @@
 //
 
 #import "DownloadViewController.h"
-@import Firebase;
+@import FirebaseStorage;
 
 @interface DownloadViewController ()
 @property (weak, nonatomic) IBOutlet UIImageView *imageView;

--- a/storage/StorageExample/ViewController.m
+++ b/storage/StorageExample/ViewController.m
@@ -18,7 +18,8 @@
 #import "ViewController.h"
 #import "DownloadViewController.h"
 
-@import Firebase;
+@import FirebaseAuth;
+@import FirebaseStorage;
 
 @interface ViewController () <UIImagePickerControllerDelegate, UINavigationControllerDelegate>
 

--- a/storage/StorageExampleSwift/AppDelegate.swift
+++ b/storage/StorageExampleSwift/AppDelegate.swift
@@ -15,7 +15,7 @@
 //
 
 import UIKit
-import Firebase
+import FirebaseCore
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/storage/StorageExampleSwift/DownloadViewController.swift
+++ b/storage/StorageExampleSwift/DownloadViewController.swift
@@ -15,7 +15,7 @@
 //
 
 import UIKit
-import Firebase
+import FirebaseStorage
 import FirebaseStorageSwift
 
 @objc(DownloadViewController)

--- a/storage/StorageExampleSwift/ViewController.swift
+++ b/storage/StorageExampleSwift/ViewController.swift
@@ -16,8 +16,8 @@
 
 import UIKit
 import Photos
-import Firebase
-import FirebaseStorageSwift
+import FirebaseAuth
+import FirebaseStorage
 
 @objc(ViewController)
 class ViewController: UIViewController,


### PR DESCRIPTION
More context at https://github.com/firebase/firebase-ios-sdk/issues/9074

The rest of this repo should be similarly updated.