### PR TITLE
Auth QS does not build with Facebook 13.0.0

### DIFF
--- a/authentication/Podfile
+++ b/authentication/Podfile
@@ -17,7 +17,7 @@ target 'AuthenticationExample' do
   pod 'GoogleSignIn'
 
   ## Pod for Sign in with Facebook
-  pod 'FBSDKLoginKit'
+  pod 'FBSDKLoginKit', '~> 12.2'
 
   target 'AuthenticationExampleTests' do
     inherit! :search_paths

--- a/authentication/Podfile.lock
+++ b/authentication/Podfile.lock
@@ -110,7 +110,7 @@ PODS:
   - PromisesObjC (2.0.0)
 
 DEPENDENCIES:
-  - FBSDKLoginKit
+  - FBSDKLoginKit (~> 12.2)
   - FirebaseAnalytics
   - FirebaseAuth
   - FirebaseDynamicLinks
@@ -159,6 +159,6 @@ SPEC CHECKSUMS:
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
 
-PODFILE CHECKSUM: 10d6cbbf1f0fad7683646923bb534d939adf5a3a
+PODFILE CHECKSUM: 582105e8acd5305b5ebc413907eef151965a42f5
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Workaround missing Facebook SDK 13.0 support to fix CI until we do a quickstart update.

See CI failures like https://github.com/firebase/firebase-ios-sdk/runs/5320909827?check_suite_focus=true#step:5:917