### PR TITLE
Fix pod install warning

### DIFF
--- a/config/ConfigExample.xcodeproj/project.pbxproj
+++ b/config/ConfigExample.xcodeproj/project.pbxproj
@@ -551,7 +551,6 @@
 		EA20B4B72497CC9F00B5E581 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ConfigExampleUITests/Info.plist;
@@ -572,7 +571,6 @@
 		EA20B4B82497CC9F00B5E581 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ConfigExampleUITests/Info.plist;


### PR DESCRIPTION
Remove the following `pod install` warning:

[!] The `ConfigExampleUITests [Debug]` target overrides the `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` build setting defined in `Pods/Target Support Files/Pods-ConfigExample-ConfigExampleUITests/Pods-ConfigExample-ConfigExampleUITests.debug.xcconfig'. This can lead to problems with the CocoaPods installation
    - Use the `$(inherited)` flag, or
    - Remove the build settings from the target.

[!] The `ConfigExampleUITests [Release]` target overrides the `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` build setting defined in `Pods/Target Support Files/Pods-ConfigExample-ConfigExampleUITests/Pods-ConfigExample-ConfigExampleUITests.release.xcconfig'. This can lead to problems with the CocoaPods installation
    - Use the `$(inherited)` flag, or
    - Remove the build settings from the target.