### PR TITLE
Storage QS updates for v9

### DIFF
--- a/storage/LegacyStorageQuickstart/Podfile
+++ b/storage/LegacyStorageQuickstart/Podfile
@@ -1,5 +1,7 @@
+#TODO: Delete next two lines on merging back to master.
 source 'https://github.com/firebase/SpecsDev.git'
 source 'https://cdn.cocoapods.org/'
+
 # StorageExample
 
 use_frameworks!

--- a/storage/LegacyStorageQuickstart/Podfile
+++ b/storage/LegacyStorageQuickstart/Podfile
@@ -1,3 +1,5 @@
+source 'https://github.com/firebase/SpecsDev.git'
+source 'https://cdn.cocoapods.org/'
 # StorageExample
 
 use_frameworks!
@@ -9,7 +11,6 @@ pod 'FirebaseStorage'
 target 'StorageExample' do
 end
 target 'StorageExampleSwift' do
-  pod 'FirebaseStorageSwift', "> 7.0-beta"
 end
 target 'StorageExampleTests' do
 end

--- a/storage/LegacyStorageQuickstart/Podfile.lock
+++ b/storage/LegacyStorageQuickstart/Podfile.lock
@@ -1,23 +1,34 @@
 PODS:
-  - FirebaseAuth (8.13.0):
-    - FirebaseCore (~> 8.0)
+  - FirebaseAppCheckInterop (9.0.0)
+  - FirebaseAuth (9.0.0):
+    - FirebaseCore (~> 9.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/Environment (~> 7.7)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseCore (8.13.0):
-    - FirebaseCoreDiagnostics (~> 8.0)
+  - FirebaseAuthInterop (9.0.0)
+  - FirebaseCore (9.0.0):
+    - FirebaseCoreDiagnostics (~> 9.0)
+    - FirebaseCoreInternal (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (8.13.0):
+  - FirebaseCoreDiagnostics (9.0.0):
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
     - nanopb (~> 2.30908.0)
-  - FirebaseStorage (8.13.0):
-    - FirebaseCore (~> 8.0)
+  - FirebaseCoreExtension (9.0.0):
+    - FirebaseCore (~> 9.0)
+  - FirebaseCoreInternal (9.0.0):
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
+  - FirebaseStorage (9.0.0):
+    - FirebaseAppCheckInterop (~> 9.0)
+    - FirebaseAuthInterop (~> 9.0)
+    - FirebaseCore (~> 9.0)
+    - FirebaseCoreExtension (~> 9.0)
+    - FirebaseStorageInternal (~> 9.0)
+  - FirebaseStorageInternal (9.0.0):
+    - FirebaseCore (~> 9.0)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseStorageSwift (8.13.0-beta):
-    - FirebaseStorage (~> 8.0)
   - GoogleDataTransport (9.1.2):
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30908.0)
@@ -37,26 +48,30 @@ PODS:
   - "GoogleUtilities/NSData+zlib (7.7.0)"
   - GoogleUtilities/Reachability (7.7.0):
     - GoogleUtilities/Logger
-  - GTMSessionFetcher/Core (1.7.0)
+  - GTMSessionFetcher/Core (1.7.1)
   - nanopb (2.30908.0):
     - nanopb/decode (= 2.30908.0)
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
-  - PromisesObjC (2.0.0)
+  - PromisesObjC (2.1.0)
 
 DEPENDENCIES:
   - FirebaseAuth
   - FirebaseStorage
-  - FirebaseStorageSwift (> 7.0-beta)
 
 SPEC REPOS:
-  trunk:
+  https://github.com/firebase/SpecsDev.git:
+    - FirebaseAppCheckInterop
     - FirebaseAuth
+    - FirebaseAuthInterop
     - FirebaseCore
     - FirebaseCoreDiagnostics
+    - FirebaseCoreExtension
+    - FirebaseCoreInternal
     - FirebaseStorage
-    - FirebaseStorageSwift
+    - FirebaseStorageInternal
+  trunk:
     - GoogleDataTransport
     - GoogleUtilities
     - GTMSessionFetcher
@@ -64,17 +79,21 @@ SPEC REPOS:
     - PromisesObjC
 
 SPEC CHECKSUMS:
-  FirebaseAuth: ee43cf9474641c673a3a215ac92ab99e5630620c
-  FirebaseCore: c7e3fa30492e50ccdeef280bf0d5584af38da3e1
-  FirebaseCoreDiagnostics: c2836d254a8f0bbb4121ff18f2c2ea39d118fd08
-  FirebaseStorage: 0f115042c1596f5df5a80b67cf414d8f028ccddd
-  FirebaseStorageSwift: 1762022e0ece4a3ada769f414474497ddad5caee
+  FirebaseAppCheckInterop: 0da214236777e71d8535c5f3b9cb5174f636a9eb
+  FirebaseAuth: 22dd8bacee07e955d153780359fe2d4cbb94822d
+  FirebaseAuthInterop: eaf74707f31a2a38cc133832d2c6410233569cbf
+  FirebaseCore: 6c77d4b88c60992152509eae56851b7e8a2507dd
+  FirebaseCoreDiagnostics: 54410e5d156bf406a764c2722d9f77d682723b4c
+  FirebaseCoreExtension: 9ce1dc5fedca6dad29fe8e2be7ee7786498dc675
+  FirebaseCoreInternal: 5b8f4f2e2970a4cb9bd1cf7ada16c8ba69a29530
+  FirebaseStorage: a5f3bfe6a9c5afaed1b6751d5a69fa176aeb0182
+  FirebaseStorageInternal: 6ab02daac3b6e2027541e342f6d29d144ae7ebec
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
-  GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
+  GTMSessionFetcher: 4577a4cc914a5a07c40a8a0ad0acc22080418c2d
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
+  PromisesObjC: 99b6f43f9e1044bd87a95a60beff28c2c44ddb72
 
-PODFILE CHECKSUM: 3db2ca4b6dfea69e157a30db8e82a984077684ca
+PODFILE CHECKSUM: 548cb7eaaaa9606456a72c04ced414acbb431a33
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/storage/LegacyStorageQuickstart/StorageExampleSwift/DownloadViewController.swift
+++ b/storage/LegacyStorageQuickstart/StorageExampleSwift/DownloadViewController.swift
@@ -16,7 +16,6 @@
 
 import UIKit
 import FirebaseStorage
-import FirebaseStorageSwift
 
 @objc(DownloadViewController)
 class DownloadViewController: UIViewController {


### PR DESCRIPTION
Updates to Storage Legacy Quickstart for v9. 

The Podfile `source` changes should be deleted after v9 releases and the v9 branch merges to master.