### PR TITLE
Added guard check for uid in "NewReviewViewController"

### DIFF
--- a/firestore/FirestoreExample/NewReviewViewController.swift
+++ b/firestore/FirestoreExample/NewReviewViewController.swift
@@ -59,8 +59,9 @@ class NewReviewViewController: UIViewController, UITextFieldDelegate {
   }
 
   @IBAction func doneButtonPressed(_ sender: Any) {
+    guard let uid = Auth.auth().currentUser?.uid else { return }
     let review = Review(rating: ratingView.rating!,
-                        userID: Auth.auth().currentUser!.uid,
+                        userID: uid,
                         username: Auth.auth().currentUser?.displayName ?? "Anonymous",
                         text: reviewTextField.text!,
                         date: Timestamp())


### PR DESCRIPTION
Problem:
If a user tries to add a review in NewReviewViewController without being logged in, the app crashes. 
Because it tries to access the "uid" property of current user forcefully, that is nil without an authenticated user.

Solution:
So I added a guard statement to prevent this crash.

Also it is a bad practice in Swift to force unwrap optional
