### PR TITLE
Firestore: Fix transparent nav bar on iOS 13+

### DIFF
--- a/firestore/FirestoreExample.xcodeproj/project.pbxproj
+++ b/firestore/FirestoreExample.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0F5846D1C922E1CBB0D0B628 /* GoogleService-Info.plist in Sources */ = {isa = PBXBuildFile; fileRef = 6AA80A371E484FE3095D24C4 /* GoogleService-Info.plist */; };
 		10734773203159E4004A66D1 /* FirestoreExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10734772203159E4004A66D1 /* FirestoreExampleUITests.swift */; };
 		1A8221B8C73DEF29AF54187B /* GoogleService-Info.plist in Sources */ = {isa = PBXBuildFile; fileRef = 6AA80A371E484FE3095D24C4 /* GoogleService-Info.plist */; };
+		8670CB2C286A218500070BC6 /* UINavigationBar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8670CB2B286A218500070BC6 /* UINavigationBar+Extension.swift */; };
 		8D004D2D1EE879B5004DEF35 /* FiltersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D004D2C1EE879B5004DEF35 /* FiltersViewController.swift */; };
 		8D5DF7021F7EF3BA00B0D24F /* NewReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5DF7011F7EF3BA00B0D24F /* NewReviewViewController.swift */; };
 		8D9BBC311EE2200900194E9A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9BBC301EE2200900194E9A /* AppDelegate.swift */; };
@@ -72,6 +73,7 @@
 		10734772203159E4004A66D1 /* FirestoreExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreExampleUITests.swift; sourceTree = "<group>"; };
 		10734774203159E4004A66D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6AA80A371E484FE3095D24C4 /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		8670CB2B286A218500070BC6 /* UINavigationBar+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationBar+Extension.swift"; sourceTree = "<group>"; };
 		8D004D2C1EE879B5004DEF35 /* FiltersViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FiltersViewController.swift; sourceTree = "<group>"; };
 		8D5DF7011F7EF3BA00B0D24F /* NewReviewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewReviewViewController.swift; sourceTree = "<group>"; };
 		8D9BBC2D1EE2200900194E9A /* FirestoreExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FirestoreExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -198,6 +200,7 @@
 				8DF77E1B1EEB645100CB2330 /* StarsView.swift */,
 				8DF1E3141EE72C4600192CDE /* LocalCollection.swift */,
 				8DF1E3121EE5CFF900192CDE /* Restaurant.swift */,
+				8670CB2B286A218500070BC6 /* UINavigationBar+Extension.swift */,
 				8D9BBC341EE2200900194E9A /* Main.storyboard */,
 				8D9BBC371EE2200900194E9A /* Assets.xcassets */,
 				8DD9ACD91F7B166900C2DD24 /* pizza-monster.png */,
@@ -481,6 +484,7 @@
 				8D9BBC331EE2200900194E9A /* RestaurantsTableViewController.swift in Sources */,
 				8D9BBC311EE2200900194E9A /* AppDelegate.swift in Sources */,
 				8DF1E3151EE72C4600192CDE /* LocalCollection.swift in Sources */,
+				8670CB2C286A218500070BC6 /* UINavigationBar+Extension.swift in Sources */,
 				8D5DF7021F7EF3BA00B0D24F /* NewReviewViewController.swift in Sources */,
 				8DF1E3131EE5CFF900192CDE /* Restaurant.swift in Sources */,
 				8DF77E1A1EEB45E500CB2330 /* RestaurantDetailViewController.swift in Sources */,

--- a/firestore/FirestoreExample/FiltersViewController.swift
+++ b/firestore/FirestoreExample/FiltersViewController.swift
@@ -56,31 +56,7 @@ class FiltersViewController: UIViewController, UIPickerViewDataSource, UIPickerV
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    configureNavigationController()
-  }
-
-  // Blue bar with white text color
-  private func configureNavigationController() {
-    guard let navigationBar = navigationController?.navigationBar else {
-      return
-    }
-
-    navigationBar.barTintColor =
-      UIColor(red: 0x3D / 0xFF, green: 0x5A / 0xFF, blue: 0xFE / 0xFF, alpha: 1.0)
-    navigationBar.isTranslucent = false
-    navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white]
-    if #available(iOS 13.0, *) {
-      let navBarAppearance = UINavigationBarAppearance()
-      navBarAppearance.configureWithOpaqueBackground()
-      navBarAppearance.backgroundColor = navigationBar.barTintColor
-      navBarAppearance.titleTextAttributes = navigationBar.titleTextAttributes!
-      navigationBar.standardAppearance = navBarAppearance
-      navigationBar.compactAppearance = navBarAppearance
-      navigationBar.scrollEdgeAppearance = navBarAppearance
-      if #available(iOS 15.0, *) {
-        navigationBar.compactScrollEdgeAppearance = navBarAppearance
-      }
-    }
+    navigationController?.navigationBar.applyFirebaseAppearance()
   }
 
   private func price(from string: String) -> Int? {

--- a/firestore/FirestoreExample/FiltersViewController.swift
+++ b/firestore/FirestoreExample/FiltersViewController.swift
@@ -56,12 +56,31 @@ class FiltersViewController: UIViewController, UIPickerViewDataSource, UIPickerV
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    // Blue bar with white color
-    navigationController?.navigationBar.barTintColor =
+    configureNavigationController()
+  }
+
+  // Blue bar with white text color
+  private func configureNavigationController() {
+    guard let navigationBar = navigationController?.navigationBar else {
+      return
+    }
+
+    navigationBar.barTintColor =
       UIColor(red: 0x3D / 0xFF, green: 0x5A / 0xFF, blue: 0xFE / 0xFF, alpha: 1.0)
-    navigationController?.navigationBar.isTranslucent = false
-    navigationController?.navigationBar.titleTextAttributes =
-      [NSAttributedString.Key.foregroundColor: UIColor.white]
+    navigationBar.isTranslucent = false
+    navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white]
+    if #available(iOS 13.0, *) {
+      let navBarAppearance = UINavigationBarAppearance()
+      navBarAppearance.configureWithOpaqueBackground()
+      navBarAppearance.backgroundColor = navigationBar.barTintColor
+      navBarAppearance.titleTextAttributes = navigationBar.titleTextAttributes!
+      navigationBar.standardAppearance = navBarAppearance
+      navigationBar.compactAppearance = navBarAppearance
+      navigationBar.scrollEdgeAppearance = navBarAppearance
+      if #available(iOS 15.0, *) {
+        navigationBar.compactScrollEdgeAppearance = navBarAppearance
+      }
+    }
   }
 
   private func price(from string: String) -> Int? {

--- a/firestore/FirestoreExample/RestaurantsTableViewController.swift
+++ b/firestore/FirestoreExample/RestaurantsTableViewController.swift
@@ -124,12 +124,25 @@ class RestaurantsTableViewController: UIViewController, UITableViewDataSource, U
     tableView.backgroundView = backgroundView
     tableView.tableFooterView = UIView()
 
-    // Blue bar with white color
+    // Blue bar with white text color
     navigationController?.navigationBar.barTintColor =
       UIColor(red: 0x3D / 0xFF, green: 0x5A / 0xFF, blue: 0xFE / 0xFF, alpha: 1.0)
     navigationController?.navigationBar.isTranslucent = false
     navigationController?.navigationBar.titleTextAttributes =
       [NSAttributedString.Key.foregroundColor: UIColor.white]
+    if #available(iOS 13.0, *) {
+      let navBarAppearance = UINavigationBarAppearance()
+      navBarAppearance.configureWithOpaqueBackground()
+      navBarAppearance.backgroundColor = navigationController!.navigationBar.barTintColor
+      navBarAppearance.titleTextAttributes =
+        navigationController!.navigationBar.titleTextAttributes!
+      navigationController?.navigationBar.standardAppearance = navBarAppearance
+      navigationController?.navigationBar.compactAppearance = navBarAppearance
+      navigationController?.navigationBar.scrollEdgeAppearance = navBarAppearance
+      if #available(iOS 15.0, *) {
+        navigationController?.navigationBar.compactScrollEdgeAppearance = navBarAppearance
+      }
+    }
 
     tableView.dataSource = self
     tableView.delegate = self

--- a/firestore/FirestoreExample/RestaurantsTableViewController.swift
+++ b/firestore/FirestoreExample/RestaurantsTableViewController.swift
@@ -124,33 +124,13 @@ class RestaurantsTableViewController: UIViewController, UITableViewDataSource, U
     tableView.backgroundView = backgroundView
     tableView.tableFooterView = UIView()
 
-    // Blue bar with white text color
-    navigationController?.navigationBar.barTintColor =
-      UIColor(red: 0x3D / 0xFF, green: 0x5A / 0xFF, blue: 0xFE / 0xFF, alpha: 1.0)
-    navigationController?.navigationBar.isTranslucent = false
-    navigationController?.navigationBar.titleTextAttributes =
-      [NSAttributedString.Key.foregroundColor: UIColor.white]
-    if #available(iOS 13.0, *) {
-      let navBarAppearance = UINavigationBarAppearance()
-      navBarAppearance.configureWithOpaqueBackground()
-      navBarAppearance.backgroundColor = navigationController!.navigationBar.barTintColor
-      navBarAppearance.titleTextAttributes =
-        navigationController!.navigationBar.titleTextAttributes!
-      navigationController?.navigationBar.standardAppearance = navBarAppearance
-      navigationController?.navigationBar.compactAppearance = navBarAppearance
-      navigationController?.navigationBar.scrollEdgeAppearance = navBarAppearance
-      if #available(iOS 15.0, *) {
-        navigationController?.navigationBar.compactScrollEdgeAppearance = navBarAppearance
-      }
-    }
+    navigationController?.navigationBar.applyFirebaseAppearance()
 
     tableView.dataSource = self
     tableView.delegate = self
     query = baseQuery()
     stackViewHeightConstraint.constant = 0
     activeFiltersStackView.isHidden = true
-
-    navigationController?.navigationBar.barStyle = .black
   }
 
   override func viewWillAppear(_ animated: Bool) {

--- a/firestore/FirestoreExample/UINavigationBar+Extension.swift
+++ b/firestore/FirestoreExample/UINavigationBar+Extension.swift
@@ -1,21 +1,16 @@
+// Copyright 2022 Google LLC
 //
-//  UINavigationBar+Extension.swift
-//  FirestoreExample
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Copyright (c) 2022 Google Inc.
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-//  http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import UIKit
 

--- a/firestore/FirestoreExample/UINavigationBar+Extension.swift
+++ b/firestore/FirestoreExample/UINavigationBar+Extension.swift
@@ -1,0 +1,56 @@
+//
+//  UINavigationBar+Extension.swift
+//  FirestoreExample
+//
+//  Copyright (c) 2022 Google Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+
+extension UINavigationBar {
+  static let firebaseBlue =
+    UIColor(red: 0x3D / 0xFF, green: 0x5A / 0xFF, blue: 0xFE / 0xFF, alpha: 1.0)
+  static let firebaseTitleTextAttributes =
+    [NSAttributedString.Key.foregroundColor: UIColor.white]
+
+  @available(iOS 13.0, *)
+  var firebaseNavigationBarAppearance: UINavigationBarAppearance {
+    let navBarAppearance = UINavigationBarAppearance()
+    navBarAppearance.configureWithOpaqueBackground()
+    navBarAppearance.backgroundColor = UINavigationBar.firebaseBlue
+    navBarAppearance.titleTextAttributes = UINavigationBar.firebaseTitleTextAttributes
+    return navBarAppearance
+  }
+
+  @available(iOS 13.0, *)
+  func applyAppearance(_ appearance: UINavigationBarAppearance) {
+    standardAppearance = appearance
+    compactAppearance = appearance
+    scrollEdgeAppearance = appearance
+    if #available(iOS 15.0, *) {
+      compactScrollEdgeAppearance = appearance
+    }
+  }
+
+  func applyFirebaseAppearance() {
+    barTintColor = UINavigationBar.firebaseBlue
+    isTranslucent = false
+    titleTextAttributes = UINavigationBar.firebaseTitleTextAttributes
+
+    if #available(iOS 13.0, *) {
+      applyAppearance(firebaseNavigationBarAppearance)
+    }
+  }
+}


### PR DESCRIPTION
Applied a UINavigationBarAppearance to fix transparent navigation bars on iOS 15, which was causing the filter view navigation bar text to overlap the restaurant list view text.

UINavigationBar background colour behaviour changed in iOS 13 and iOS 15, as described in [TN3106: Customizing the appearance of UINavigationBar](https://developer.apple.com/documentation/technotes/tn3106-customizing-uinavigationbar-appearance).