### PR TITLE
Print JSON decoding error instead of crashing app

### DIFF
--- a/config/ConfigExample/RemoteConfigViewController.swift
+++ b/config/ConfigExample/RemoteConfigViewController.swift
@@ -160,7 +160,8 @@ class RemoteConfigViewController: UIViewController {
     }
 
     guard let recipe: Recipe = try? remoteConfig[typedRecipeKey].decoded() else {
-      fatalError("Failed to decode JSON for \(typedRecipeKey)")
+      print("Failed to decode JSON for \(typedRecipeKey)")
+      return
     }
     let lines = recipe.description.split(separator: "\n")
     for (index, line) in lines.enumerated() {


### PR DESCRIPTION
when `typedRecipeKey` isn't defined or isn't the correct recipe format the app crashes