### PR TITLE
RTDB: Prevent blank new message posts

### DIFF
--- a/database/DatabaseExample/NewPostViewController.m
+++ b/database/DatabaseExample/NewPostViewController.m
@@ -17,6 +17,7 @@
 #import "NewPostViewController.h"
 #import "User.h"
 #import "Post.h"
+#import "UIViewController+Alerts.h"
 @import FirebaseDatabase;
 @import FirebaseAuth;
 
@@ -52,6 +53,10 @@
 }
 
 - (IBAction)didTapShare:(id)sender {
+  if (self.titleTextField.text.length == 0 || self.bodyTextView.text.length == 0) {
+    [self showMessagePrompt:@"Neither title nor body can be empty."];
+    return;
+  }
   // [START single_value_read]
   NSString *userID = [FIRAuth auth].currentUser.uid;
   [[[_ref child:@"users"] child:userID] observeSingleEventOfType:FIRDataEventTypeValue withBlock:^(FIRDataSnapshot * _Nonnull snapshot) {

--- a/database/DatabaseExampleSwift/NewPostViewController.swift
+++ b/database/DatabaseExampleSwift/NewPostViewController.swift
@@ -49,6 +49,16 @@ class NewPostViewController: UIViewController, UITextFieldDelegate {
   }
 
   @IBAction func didTapShare(_ sender: AnyObject) {
+    guard titleTextField.hasText, bodyTextView.hasText else {
+      let alert = UIAlertController(
+        title: nil,
+        message: "Neither title nor body can be empty.",
+        preferredStyle: .alert
+      )
+      alert.addAction(UIAlertAction(title: "OK", style: .default))
+      present(alert, animated: true, completion: nil)
+      return
+    }
     // [START single_value_read]
     let userID = Auth.auth().currentUser?.uid
     ref.child("users").child(userID!).observeSingleEvent(of: .value, with: { snapshot in


### PR DESCRIPTION
Updated the RTDB ObjC and Swift (UIKit) quickstarts to show an alert when attempting to post a new message missing a title or body. This makes them [consistent](https://github.com/firebase/quickstart-ios/blob/971254d94b4c8536176add666cfb0c1f71648050/database/DatabaseExampleSwiftUI/DatabaseExample/Shared/Models/PostListViewModel.swift#L42-L46) with the SwiftUI quickstart.