### PR TITLE
[Firestore] Sample for reproducing data encoding change

### DIFF
--- a/firestore/FirestoreExample.xcodeproj/project.pbxproj
+++ b/firestore/FirestoreExample.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		10734773203159E4004A66D1 /* FirestoreExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10734772203159E4004A66D1 /* FirestoreExampleUITests.swift */; };
 		1A8221B8C73DEF29AF54187B /* GoogleService-Info.plist in Sources */ = {isa = PBXBuildFile; fileRef = 6AA80A371E484FE3095D24C4 /* GoogleService-Info.plist */; };
 		8670CB2C286A218500070BC6 /* UINavigationBar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8670CB2B286A218500070BC6 /* UINavigationBar+Extension.swift */; };
+		8695F0AD2950FA5C00F584B1 /* FirestoreBlobView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8695F0AC2950FA5C00F584B1 /* FirestoreBlobView.swift */; };
 		8D004D2D1EE879B5004DEF35 /* FiltersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D004D2C1EE879B5004DEF35 /* FiltersViewController.swift */; };
 		8D5DF7021F7EF3BA00B0D24F /* NewReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5DF7011F7EF3BA00B0D24F /* NewReviewViewController.swift */; };
 		8D9BBC311EE2200900194E9A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9BBC301EE2200900194E9A /* AppDelegate.swift */; };
@@ -74,6 +75,7 @@
 		10734774203159E4004A66D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6AA80A371E484FE3095D24C4 /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		8670CB2B286A218500070BC6 /* UINavigationBar+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationBar+Extension.swift"; sourceTree = "<group>"; };
+		8695F0AC2950FA5C00F584B1 /* FirestoreBlobView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreBlobView.swift; sourceTree = "<group>"; };
 		8D004D2C1EE879B5004DEF35 /* FiltersViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FiltersViewController.swift; sourceTree = "<group>"; };
 		8D5DF7011F7EF3BA00B0D24F /* NewReviewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewReviewViewController.swift; sourceTree = "<group>"; };
 		8D9BBC2D1EE2200900194E9A /* FirestoreExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FirestoreExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -254,6 +256,7 @@
 		8E4C62E125E9D137001678A1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				8695F0AC2950FA5C00F584B1 /* FirestoreBlobView.swift */,
 				8E4C62D225E9CFE0001678A1 /* RestaurantListView.swift */,
 				8E4C62E625E9D191001678A1 /* RestaurantItemView.swift */,
 				8E919E7D260D3956007C62C4 /* RestaurantDetailView.swift */,
@@ -508,6 +511,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8E1E43B125F961EF00BC64D3 /* Restaurant+Extension.swift in Sources */,
+				8695F0AD2950FA5C00F584B1 /* FirestoreBlobView.swift in Sources */,
 				8E4C62D325E9CFE0001678A1 /* RestaurantListView.swift in Sources */,
 				8E722C0B261CD4210047AA1A /* RestaurantHeaderView.swift in Sources */,
 				8E4C634925EDB793001678A1 /* Restaurant.swift in Sources */,

--- a/firestore/FirestoreSwiftUIExample/FirestoreSwiftUIExampleApp.swift
+++ b/firestore/FirestoreSwiftUIExample/FirestoreSwiftUIExampleApp.swift
@@ -28,7 +28,9 @@ struct FirestoreSwiftUIExampleApp: App {
 
   var body: some Scene {
     WindowGroup {
-      SignInView()
+      NavigationView {
+        FirestoreBlobView()
+      }
     }
   }
 }

--- a/firestore/FirestoreSwiftUIExample/Views/FirestoreBlobView.swift
+++ b/firestore/FirestoreSwiftUIExample/Views/FirestoreBlobView.swift
@@ -1,0 +1,102 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+import Gzip
+import SwiftUI
+
+struct FirestoreBlobView: View {
+  @State private var showingAlert = false
+  @State private var alert = Alert(title: Text(""))
+
+  var body: some View {
+    VStack(spacing: 20.0) {
+      Button("Insert Blob") {
+        insertBlob()
+      }.alert(isPresented: $showingAlert) {
+        alert
+      }
+    }.navigationTitle("Firestore Blob Tester")
+  }
+
+  private func insertBlob() {
+    let db = Firestore.firestore()
+
+    // creates a test document with a CSV string and the corresponding Data and gzipped Data
+    let csvString =
+      "fruit,\nbanana,yellow,round\n,fruit,orange,orange,round\nfruit,\napple,red,round"
+    let csvData = csvString.data(using: .utf8)!
+    let csvZipped: Data
+    do {
+      csvZipped = try csvData.gzipped()
+    } catch {
+      alert = Alert(
+        title: Text("GZip Error"),
+        message: Text(error.localizedDescription)
+      )
+      showingAlert = true
+      return
+    }
+
+    let document =
+      TestDocument(csvString: csvString, csvData: csvData, csvZipped: csvZipped)
+
+    // store the Document in Firestore
+    let documentID = UUID().uuidString
+    let firestoreEncoder = Firestore.Encoder()
+    let documentData: [String: Any]
+    do {
+      documentData = try firestoreEncoder.encode(document)
+    } catch {
+      alert = Alert(
+        title: Text("Encoding Error"),
+        message: Text(error.localizedDescription)
+      )
+      showingAlert = true
+      return
+    }
+
+    db.collection("tests").document(documentID).setData(documentData) { error in
+      if let error = error {
+        print("Error inserting the document: \(error.localizedDescription)")
+        alert = Alert(
+          title: Text("Document Insertion Error"),
+          message: Text(error.localizedDescription)
+        )
+      } else {
+        print("Document inserted successfully")
+        alert = Alert(title: Text("Document Inserted Successfully"))
+      }
+      showingAlert = true
+    }
+  }
+}
+
+struct FirestoreBlobView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      FirestoreBlobView()
+    }
+  }
+}
+
+// The test document
+private struct TestDocument: Codable {
+  @DocumentID var id: String?
+  @ServerTimestamp var timestamp: Timestamp?
+  let csvString: String
+  let csvData: Data
+  let csvZipped: Data
+}

--- a/firestore/Podfile
+++ b/firestore/Podfile
@@ -7,7 +7,7 @@ target 'FirestoreExample' do
   pod 'FirebaseUI/Auth', '~> 12.0'
   pod 'FirebaseUI/Email', '~> 12.0'
   pod 'FirebaseFirestore'
-  pod 'FirebaseFirestoreSwift', "> 7.0-beta"
+  pod 'FirebaseFirestoreSwift'
   pod 'SDWebImage'
 
   target 'FirestoreExampleTests' do
@@ -20,6 +20,7 @@ target 'FirestoreSwiftUIExample' do
 
   pod 'FirebaseAuth'
   pod 'FirebaseFirestore'
-  pod 'FirebaseFirestoreSwift', "> 7.0-beta"
+  pod 'FirebaseFirestoreSwift'
+  pod 'GzipSwift'
   pod 'SDWebImageSwiftUI'
 end

--- a/firestore/Podfile.lock
+++ b/firestore/Podfile.lock
@@ -602,28 +602,28 @@ PODS:
   - BoringSSL-GRPC/Implementation (0.0.24):
     - BoringSSL-GRPC/Interface (= 0.0.24)
   - BoringSSL-GRPC/Interface (0.0.24)
-  - FirebaseAuth (10.0.0):
+  - FirebaseAuth (10.3.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
-    - GTMSessionFetcher/Core (~> 2.1)
+    - GTMSessionFetcher/Core (< 4.0, >= 2.1)
   - FirebaseAuthUI (12.3.0):
     - FirebaseAuth (< 11.0, >= 8.0)
     - FirebaseCore
-  - FirebaseCore (10.0.0):
+  - FirebaseCore (10.3.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreExtension (10.0.0):
+  - FirebaseCoreExtension (10.3.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.0.0):
+  - FirebaseCoreInternal (10.3.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - FirebaseEmailAuthUI (12.3.0):
     - FirebaseAuth
     - FirebaseAuthUI
     - FirebaseCore
     - GoogleUtilities/UserDefaults
-  - FirebaseFirestore (10.0.0):
+  - FirebaseFirestore (10.3.0):
     - abseil/algorithm (~> 1.20211102.0)
     - abseil/base (~> 1.20211102.0)
     - abseil/container/flat_hash_map (~> 1.20211102.0)
@@ -636,32 +636,32 @@ PODS:
     - "gRPC-C++ (~> 1.44.0)"
     - leveldb-library (~> 1.22)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseFirestoreSwift (10.0.0):
+  - FirebaseFirestoreSwift (10.3.0):
     - FirebaseCore (~> 10.0)
     - FirebaseCoreExtension (~> 10.0)
     - FirebaseFirestore (~> 10.0)
     - FirebaseSharedSwift (~> 10.0)
-  - FirebaseSharedSwift (10.0.0)
+  - FirebaseSharedSwift (10.3.0)
   - FirebaseUI/Auth (12.3.0):
     - FirebaseAuthUI (~> 12.0)
   - FirebaseUI/Email (12.3.0):
     - FirebaseEmailAuthUI (~> 12.0)
-  - GoogleUtilities/AppDelegateSwizzler (7.8.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.10.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.8.0):
+  - GoogleUtilities/Environment (7.10.0):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.8.0):
+  - GoogleUtilities/Logger (7.10.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (7.8.0):
+  - GoogleUtilities/Network (7.10.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.8.0)"
-  - GoogleUtilities/Reachability (7.8.0):
+  - "GoogleUtilities/NSData+zlib (7.10.0)"
+  - GoogleUtilities/Reachability (7.10.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.8.0):
+  - GoogleUtilities/UserDefaults (7.10.0):
     - GoogleUtilities/Logger
   - "gRPC-C++ (1.44.0)":
     - "gRPC-C++/Implementation (= 1.44.0)"
@@ -714,7 +714,8 @@ PODS:
     - gRPC-Core/Interface (= 1.44.0)
     - Libuv-gRPC (= 0.0.10)
   - gRPC-Core/Interface (1.44.0)
-  - GTMSessionFetcher/Core (2.1.0)
+  - GTMSessionFetcher/Core (3.0.0)
+  - GzipSwift (5.1.1)
   - leveldb-library (1.22.1)
   - Libuv-gRPC (0.0.10):
     - Libuv-gRPC/Implementation (= 0.0.10)
@@ -728,18 +729,19 @@ PODS:
   - nanopb/decode (2.30909.0)
   - nanopb/encode (2.30909.0)
   - PromisesObjC (2.1.1)
-  - SDWebImage (5.13.4):
-    - SDWebImage/Core (= 5.13.4)
-  - SDWebImage/Core (5.13.4)
+  - SDWebImage (5.14.2):
+    - SDWebImage/Core (= 5.14.2)
+  - SDWebImage/Core (5.14.2)
   - SDWebImageSwiftUI (2.2.1):
     - SDWebImage (~> 5.10)
 
 DEPENDENCIES:
   - FirebaseAuth
   - FirebaseFirestore
-  - FirebaseFirestoreSwift (> 7.0-beta)
+  - FirebaseFirestoreSwift
   - FirebaseUI/Auth (~> 12.0)
   - FirebaseUI/Email (~> 12.0)
+  - GzipSwift
   - SDWebImage
   - SDWebImageSwiftUI
 
@@ -761,6 +763,7 @@ SPEC REPOS:
     - "gRPC-C++"
     - gRPC-Core
     - GTMSessionFetcher
+    - GzipSwift
     - leveldb-library
     - Libuv-gRPC
     - nanopb
@@ -771,27 +774,28 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   abseil: ebe5b5529fb05d93a8bdb7951607be08b7fa71bc
   BoringSSL-GRPC: 3175b25143e648463a56daeaaa499c6cb86dad33
-  FirebaseAuth: 493382cf533cc45e2862b00e9aa4cfe4c98daf71
+  FirebaseAuth: 0e415d29d846c1dce2fb641e46f35e9888d9bec6
   FirebaseAuthUI: 9fa83d7dd7bad0f0eb20a9682f7e649c98e8f644
-  FirebaseCore: 97f48a3a567a72b8d4daa0f03c3aadb78df4e995
-  FirebaseCoreExtension: 449595a035812f16314ca88cebf959e3bb77dd67
-  FirebaseCoreInternal: 5eb3960335da5ea30115d57d39db6988c4ad06f3
+  FirebaseCore: 988754646ab3bd4bdcb740f1bfe26b9f6c0d5f2a
+  FirebaseCoreExtension: 93d252fabdc9696bf14a73b04d84877ab9b3a832
+  FirebaseCoreInternal: 29b76f784d607df8b2a1259d73c3f04f1210137b
   FirebaseEmailAuthUI: 93c49123133a5ff934e05d15c51462ed0f12ee0a
-  FirebaseFirestore: 5007583f3db2129de8e87f18ee63f4c86f07e7a3
-  FirebaseFirestoreSwift: a67b697245c5f6e721612fc86e1f26384c90ddcf
-  FirebaseSharedSwift: eae0978bbb46dbfc21975e88a79654f614822ce4
+  FirebaseFirestore: 244f71ff14ef44f39e00b44d356eac708ce03103
+  FirebaseFirestoreSwift: 55098402529ce59ba54a2ce1ad5798ae1ba563ef
+  FirebaseSharedSwift: d82ad66b3f8de9dda19c77b9627cbcaad71e245e
   FirebaseUI: e9a2dd42f5b593cd8b6e64c11d30ded38f30e48c
-  GoogleUtilities: 1d20a6ad97ef46f67bbdec158ce00563a671ebb7
+  GoogleUtilities: bad72cb363809015b1f7f19beb1f1cd23c589f95
   "gRPC-C++": 9675f953ace2b3de7c506039d77be1f2e77a8db2
   gRPC-Core: 943e491cb0d45598b0b0eb9e910c88080369290b
-  GTMSessionFetcher: ffbb25ec00ebcb5201adab0a56d808f6f1902d9f
+  GTMSessionFetcher: c1edebe64e9fb4e8f6415d018edf1fd3eac074a1
+  GzipSwift: 893f3e48e597a1a4f62fafcb6514220fcf8287fa
   leveldb-library: 50c7b45cbd7bf543c81a468fe557a16ae3db8729
   Libuv-gRPC: 55e51798e14ef436ad9bc45d12d43b77b49df378
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
-  SDWebImage: e5cc87bf736e60f49592f307bdf9e157189298a3
+  SDWebImage: b9a731e1d6307f44ca703b3976d18c24ca561e84
   SDWebImageSwiftUI: 2ecf5ab6f574526326b10ecb155e72a88059d0f0
 
-PODFILE CHECKSUM: 4dc670c18cc786f253fe074fffb67f14f15586d6
+PODFILE CHECKSUM: 68278d8cdaa6746f0ab87401fdc9d220bb6cd903
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Added sample code to demonstrate the data encoding change from pre to post-Firebase 10.0. `Data` objects used to be written to Firestore as the Blob type and are now encoded as base64 strings.

See [PR #10592](https://github.com/firebase/firebase-ios-sdk/pull/10592) for the related SDK change.