### PR TITLE
[Auth] Update 'randomNonceString' implementation

### DIFF
--- a/authentication/AuthenticationExample.xcodeproj/project.pbxproj
+++ b/authentication/AuthenticationExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -16,6 +16,7 @@
 		EA02F68524A000E00079D000 /* UserActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA02F68424A000E00079D000 /* UserActions.swift */; };
 		EA02F68D24A063E90079D000 /* LoginDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA02F68C24A063E90079D000 /* LoginDelegate.swift */; };
 		EA062D5D24A0FEB6006714D3 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = EA062D5C24A0FEB6006714D3 /* README.md */; };
+		EA12697F29E33A5D00D79E66 /* CryptoUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA12697E29E33A5D00D79E66 /* CryptoUtils.swift */; };
 		EA20B46C2495A9F900B5E581 /* SignedOutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA20B46B2495A9F900B5E581 /* SignedOutView.swift */; };
 		EA20B46E2495B2C700B5E581 /* DataSourceProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA20B46D2495B2C700B5E581 /* DataSourceProtocols.swift */; };
 		EA20B503249C6C3D00B5E581 /* CustomAuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA20B502249C6C3D00B5E581 /* CustomAuthViewController.swift */; };
@@ -72,6 +73,7 @@
 		EA02F68424A000E00079D000 /* UserActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserActions.swift; sourceTree = "<group>"; };
 		EA02F68C24A063E90079D000 /* LoginDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginDelegate.swift; sourceTree = "<group>"; };
 		EA062D5C24A0FEB6006714D3 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
+		EA12697E29E33A5D00D79E66 /* CryptoUtils.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = CryptoUtils.swift; sourceTree = "<group>"; tabWidth = 2; };
 		EA20B46B2495A9F900B5E581 /* SignedOutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedOutView.swift; sourceTree = "<group>"; };
 		EA20B46D2495B2C700B5E581 /* DataSourceProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSourceProtocols.swift; sourceTree = "<group>"; };
 		EA20B502249C6C3D00B5E581 /* CustomAuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAuthViewController.swift; sourceTree = "<group>"; };
@@ -219,6 +221,7 @@
 			isa = PBXGroup;
 			children = (
 				EAEBCE0E2489FFDE00FCEA92 /* Extensions.swift */,
+				EA12697E29E33A5D00D79E66 /* CryptoUtils.swift */,
 				EA02F68C24A063E90079D000 /* LoginDelegate.swift */,
 				EA20B47924973C0400B5E581 /* DataSourceProvider */,
 				EA20B47824973BEC00B5E581 /* TransitionAnimator */,
@@ -537,6 +540,7 @@
 				EA20B50A249D3D8600B5E581 /* PasswordlessViewController.swift in Sources */,
 				EAE4CBF524857A5100245E92 /* LoginController.swift in Sources */,
 				EA20B510249FDB4400B5E581 /* OtherAuthMethods.swift in Sources */,
+				EA12697F29E33A5D00D79E66 /* CryptoUtils.swift in Sources */,
 				EAEBCE11248A9AA000FCEA92 /* Section.swift in Sources */,
 				EA20B503249C6C3D00B5E581 /* CustomAuthViewController.swift in Sources */,
 				EAE4CBC524855E3A00245E92 /* AppDelegate.swift in Sources */,

--- a/authentication/AuthenticationExample/Utility/CryptoUtils.swift
+++ b/authentication/AuthenticationExample/Utility/CryptoUtils.swift
@@ -17,36 +17,36 @@ import CryptoKit
 
 /// Set of utility APIs for generating cryptographical artifacts.
 enum CryptoUtils {
-    enum NonceGenerationError: Error {
-        case generationFailure(status: OSStatus)
+  enum NonceGenerationError: Error {
+    case generationFailure(status: OSStatus)
+  }
+
+  static func randomNonceString(length: Int = 32) throws -> String {
+    precondition(length > 0)
+    var randomBytes = [UInt8](repeating: 0, count: length)
+    let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+    if errorCode != errSecSuccess {
+      throw NonceGenerationError.generationFailure(status: errorCode)
     }
 
-    static func randomNonceString(length: Int = 32) throws -> String {
-        precondition(length > 0)
-        var randomBytes = [UInt8](repeating: 0, count: length)
-        let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
-        if errorCode != errSecSuccess {
-            throw NonceGenerationError.generationFailure(status: errorCode)
-        }
+    let charset: [Character] =
+      Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
 
-        let charset: [Character] =
-          Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
-
-        let nonce = randomBytes.map { byte in
-            // Pick a random character from the set, wrapping around if needed.
-            return charset[Int(byte) % charset.count]
-        }
-
-        return String(nonce)
+    let nonce = randomBytes.map { byte in
+      // Pick a random character from the set, wrapping around if needed.
+      charset[Int(byte) % charset.count]
     }
 
-    static func sha256(_ input: String) -> String {
-      let inputData = Data(input.utf8)
-      let hashedData = SHA256.hash(data: inputData)
-      let hashString = hashedData.compactMap {
-        String(format: "%02x", $0)
-      }.joined()
+    return String(nonce)
+  }
 
-      return hashString
-    }
+  static func sha256(_ input: String) -> String {
+    let inputData = Data(input.utf8)
+    let hashedData = SHA256.hash(data: inputData)
+    let hashString = hashedData.compactMap {
+      String(format: "%02x", $0)
+    }.joined()
+
+    return hashString
+  }
 }

--- a/authentication/AuthenticationExample/Utility/CryptoUtils.swift
+++ b/authentication/AuthenticationExample/Utility/CryptoUtils.swift
@@ -1,0 +1,52 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import CryptoKit
+
+/// Set of utility APIs for generating cryptographical artifacts.
+enum CryptoUtils {
+    enum NonceGenerationError: Error {
+        case generationFailure(status: OSStatus)
+    }
+
+    static func randomNonceString(length: Int = 32) throws -> String {
+        precondition(length > 0)
+        var randomBytes = [UInt8](repeating: 0, count: length)
+        let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+        if errorCode != errSecSuccess {
+            throw NonceGenerationError.generationFailure(status: errorCode)
+        }
+
+        let charset: [Character] =
+          Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+
+        let nonce = randomBytes.map { byte in
+            // Pick a random character from the set, wrapping around if needed.
+            return charset[Int(byte) % charset.count]
+        }
+
+        return String(nonce)
+    }
+
+    static func sha256(_ input: String) -> String {
+      let inputData = Data(input.utf8)
+      let hashedData = SHA256.hash(data: inputData)
+      let hashString = hashedData.compactMap {
+        String(format: "%02x", $0)
+      }.joined()
+
+      return hashString
+    }
+}

--- a/authentication/AuthenticationExample/ViewControllers/AccountLinkingViewController.swift
+++ b/authentication/AuthenticationExample/ViewControllers/AccountLinkingViewController.swift
@@ -44,6 +44,7 @@ class AccountLinkingViewController: UIViewController, DataSourceProviderDelegate
     super.init(nibName: nil, bundle: nil)
   }
 
+  @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
@@ -193,7 +194,7 @@ class AccountLinkingViewController: UIViewController, DataSourceProviderDelegate
       authorizationController.performRequests()
     } catch {
       // In the unlikely case that nonce generation fails, show error view.
-      self.displayError(error)
+      displayError(error)
     }
   }
 
@@ -430,7 +431,7 @@ extension AccountLinkingViewController: DataSourceProvidable {
 
   private func buildSections() -> [Section] {
     var section = AuthProvider.authLinkSections.first!
-    section.items = section.items.compactMap { (item) -> Item? in
+    section.items = section.items.compactMap { item -> Item? in
       var item = item
       item.hasNestedContent = false
       item.isChecked = userProviderDataContains(item: item)

--- a/authentication/AuthenticationExample/ViewControllers/AccountLinkingViewController.swift
+++ b/authentication/AuthenticationExample/ViewControllers/AccountLinkingViewController.swift
@@ -178,7 +178,7 @@ class AccountLinkingViewController: UIViewController, DataSourceProviderDelegate
   /// This method will initate the Sign In with Apple flow.
   /// See this class's conformance to `ASAuthorizationControllerDelegate` below for
   /// context on how the linking is made.
-  private func performAppleAccountLink() throws {
+  private func performAppleAccountLink() {
     do {
       let nonce = try CryptoUtils.randomNonceString()
       currentNonce = nonce

--- a/authentication/AuthenticationExample/ViewControllers/AccountLinkingViewController.swift
+++ b/authentication/AuthenticationExample/ViewControllers/AccountLinkingViewController.swift
@@ -178,18 +178,23 @@ class AccountLinkingViewController: UIViewController, DataSourceProviderDelegate
   /// This method will initate the Sign In with Apple flow.
   /// See this class's conformance to `ASAuthorizationControllerDelegate` below for
   /// context on how the linking is made.
-  private func performAppleAccountLink() {
-    let nonce = randomNonceString()
-    currentNonce = nonce
-    let appleIDProvider = ASAuthorizationAppleIDProvider()
-    let request = appleIDProvider.createRequest()
-    request.requestedScopes = [.fullName, .email]
-    request.nonce = sha256(nonce)
+  private func performAppleAccountLink() throws {
+    do {
+      let nonce = try CryptoUtils.randomNonceString()
+      currentNonce = nonce
+      let appleIDProvider = ASAuthorizationAppleIDProvider()
+      let request = appleIDProvider.createRequest()
+      request.requestedScopes = [.fullName, .email]
+      request.nonce = CryptoUtils.sha256(nonce)
 
-    let authorizationController = ASAuthorizationController(authorizationRequests: [request])
-    authorizationController.delegate = self
-    authorizationController.presentationContextProvider = self
-    authorizationController.performRequests()
+      let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+      authorizationController.delegate = self
+      authorizationController.presentationContextProvider = self
+      authorizationController.performRequests()
+    } catch {
+      // In the unlikely case that nonce generation fails, show error view.
+      self.displayError(error)
+    }
   }
 
   // MARK: - Twitter, Microsoft, GitHub, Yahoo Account Linking 🔥
@@ -485,52 +490,5 @@ extension AccountLinkingViewController: ASAuthorizationControllerDelegate,
 
   func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
     return view.window!
-  }
-
-  // MARK: Aditional `Sign in with Apple` Helpers
-
-  // Adapted from https://auth0.com/docs/api-auth/tutorials/nonce#generate-a-cryptographically-random-nonce
-  private func randomNonceString(length: Int = 32) -> String {
-    precondition(length > 0)
-    let charset: [Character] =
-      Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
-    var result = ""
-    var remainingLength = length
-
-    while remainingLength > 0 {
-      let randoms: [UInt8] = (0 ..< 16).map { _ in
-        var random: UInt8 = 0
-        let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
-        if errorCode != errSecSuccess {
-          fatalError(
-            "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
-          )
-        }
-        return random
-      }
-
-      randoms.forEach { random in
-        if remainingLength == 0 {
-          return
-        }
-
-        if random < charset.count {
-          result.append(charset[Int(random)])
-          remainingLength -= 1
-        }
-      }
-    }
-
-    return result
-  }
-
-  private func sha256(_ input: String) -> String {
-    let inputData = Data(input.utf8)
-    let hashedData = SHA256.hash(data: inputData)
-    let hashString = hashedData.compactMap {
-      String(format: "%02x", $0)
-    }.joined()
-
-    return hashString
   }
 }

--- a/authentication/AuthenticationExample/ViewControllers/AuthViewController.swift
+++ b/authentication/AuthenticationExample/ViewControllers/AuthViewController.swift
@@ -167,7 +167,7 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
       authorizationController.performRequests()
     } catch {
       // In the unlikely case that nonce generation fails, show error view.
-      self.displayError(error)
+      displayError(error)
     }
   }
 

--- a/authentication/AuthenticationExample/ViewControllers/AuthViewController.swift
+++ b/authentication/AuthenticationExample/ViewControllers/AuthViewController.swift
@@ -153,17 +153,22 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
   var currentNonce: String?
 
   private func performAppleSignInFlow() {
-    let nonce = randomNonceString()
-    currentNonce = nonce
-    let appleIDProvider = ASAuthorizationAppleIDProvider()
-    let request = appleIDProvider.createRequest()
-    request.requestedScopes = [.fullName, .email]
-    request.nonce = sha256(nonce)
+    do {
+      let nonce = try CryptoUtils.randomNonceString()
+      currentNonce = nonce
+      let appleIDProvider = ASAuthorizationAppleIDProvider()
+      let request = appleIDProvider.createRequest()
+      request.requestedScopes = [.fullName, .email]
+      request.nonce = CryptoUtils.sha256(nonce)
 
-    let authorizationController = ASAuthorizationController(authorizationRequests: [request])
-    authorizationController.delegate = self
-    authorizationController.presentationContextProvider = self
-    authorizationController.performRequests()
+      let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+      authorizationController.delegate = self
+      authorizationController.presentationContextProvider = self
+      authorizationController.performRequests()
+    } catch {
+      // In the unlikely case that nonce generation fails, show error view.
+      self.displayError(error)
+    }
   }
 
   private func performFacebookSignInFlow() {
@@ -320,52 +325,5 @@ extension AuthViewController: ASAuthorizationControllerDelegate,
 
   func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
     return view.window!
-  }
-
-  // MARK: Aditional `Sign in with Apple` Helpers
-
-  // Adapted from https://auth0.com/docs/api-auth/tutorials/nonce#generate-a-cryptographically-random-nonce
-  private func randomNonceString(length: Int = 32) -> String {
-    precondition(length > 0)
-    let charset: [Character] =
-      Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
-    var result = ""
-    var remainingLength = length
-
-    while remainingLength > 0 {
-      let randoms: [UInt8] = (0 ..< 16).map { _ in
-        var random: UInt8 = 0
-        let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
-        if errorCode != errSecSuccess {
-          fatalError(
-            "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
-          )
-        }
-        return random
-      }
-
-      randoms.forEach { random in
-        if remainingLength == 0 {
-          return
-        }
-
-        if random < charset.count {
-          result.append(charset[Int(random)])
-          remainingLength -= 1
-        }
-      }
-    }
-
-    return result
-  }
-
-  private func sha256(_ input: String) -> String {
-    let inputData = Data(input.utf8)
-    let hashedData = SHA256.hash(data: inputData)
-    let hashString = hashedData.compactMap {
-      String(format: "%02x", $0)
-    }.joined()
-
-    return hashString
   }
 }

--- a/authentication/LegacyAuthQuickstart/AuthenticationExampleSwift/MainViewController.swift
+++ b/authentication/LegacyAuthQuickstart/AuthenticationExampleSwift/MainViewController.swift
@@ -1041,41 +1041,26 @@ class MainViewController: UITableViewController {
   }
 
   // [START random_nonce]
-  // Adapted from https://auth0.com/docs/api-auth/tutorials/nonce#generate-a-cryptographically-random-nonce
   private func randomNonceString(length: Int = 32) -> String {
     precondition(length > 0)
-    let charset: [Character] =
-      Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
-    var result = ""
-    var remainingLength = length
-
-    while remainingLength > 0 {
-      let randoms: [UInt8] = (0 ..< 16).map { _ in
-        var random: UInt8 = 0
-        let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
-        if errorCode != errSecSuccess {
-          fatalError(
-            "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
-          )
-        }
-        return random
-      }
-
-      randoms.forEach { random in
-        if remainingLength == 0 {
-          return
-        }
-
-        if random < charset.count {
-          result.append(charset[Int(random)])
-          remainingLength -= 1
-        }
-      }
+    var randomBytes = [UInt8](repeating: 0, count: length)
+    let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+    if errorCode != errSecSuccess {
+      fatalError(
+        "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
+      )
     }
 
-    return result
-  }
+    let charset: [Character] =
+      Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
 
+    let nonce = randomBytes.map { byte in
+      // Pick a random character from the set, wrapping around if needed.
+      return charset[Int(byte) % charset.count]
+    }
+
+    return String(nonce)
+  }
   // [END random_nonce]
 
   // [START sha_256]

--- a/authentication/LegacyAuthQuickstart/AuthenticationExampleSwift/MainViewController.swift
+++ b/authentication/LegacyAuthQuickstart/AuthenticationExampleSwift/MainViewController.swift
@@ -19,6 +19,7 @@ import CryptoKit
 import GameKit
 import UIKit
 
+import FirebaseCore
 import Security
 
 // [START usermanagement_view_import]
@@ -1056,11 +1057,12 @@ class MainViewController: UITableViewController {
 
     let nonce = randomBytes.map { byte in
       // Pick a random character from the set, wrapping around if needed.
-      return charset[Int(byte) % charset.count]
+      charset[Int(byte) % charset.count]
     }
 
     return String(nonce)
   }
+
   // [END random_nonce]
 
   // [START sha_256]


### PR DESCRIPTION
### Context 
The nonce generation we use in the sample (and correspondingly on the docs site) can be simplified. I gave it a go and came to the following solution. Any further feedback/alternative approaches welcome.

For more context, see https://github.com/firebase/firebase-ios-sdk/discussions/10732#discussion-4787797

### Before (currently on docs site):
```swift
// Adapted from https://auth0.com/docs/api-auth/tutorials/nonce#generate-a-cryptographically-random-nonce
private func randomNonceString(length: Int = 32) -> String {
  precondition(length > 0)
  let charset: [Character] =
    Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
  var result = ""
  var remainingLength = length

  while remainingLength > 0 {
    let randoms: [UInt8] = (0 ..< 16).map { _ in
      var random: UInt8 = 0
      let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
      if errorCode != errSecSuccess {
        fatalError(
          "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
        )
      }
      return random
    }

    randoms.forEach { random in
      if remainingLength == 0 {
        return
      }

      if random < charset.count {
        result.append(charset[Int(random)])
        remainingLength -= 1
      }
    }
  }

  return result
}
```

### Proposed
```swift
enum NonceGenerationError: Error {
    case generationFailure(status: OSStatus)
}

private func randomNonce(length: Int = 32) throws -> String {
    precondition(length > 0)
    var randomBytes = [UInt8](repeating: 0, count: length)
    let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
    if errorCode != errSecSuccess {
        throw NonceGenerationError.generationFailure(status: errorCode)
    }

    let charset: [Character] =
      Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")

    let nonce = randomBytes.map { byte in
        // Pick a random character from the set, wrapping around if needed.
        return charset[Int(byte) % charset.count]
    }

    return String(nonce)
}
```