### PR TITLE
Update Storage quickstart to depend on Firebase 10.x

### DIFF
--- a/storage/StorageExample/StorageExample.xcodeproj/project.pbxproj
+++ b/storage/StorageExample/StorageExample.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		864F1AB82A964D11009743F2 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 864F1AB72A964D11009743F2 /* FirebaseStorage */; };
+		864F1ABA2A964D27009743F2 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 864F1AB92A964D27009743F2 /* FirebaseStorage */; };
+		864F1ABC2A964D31009743F2 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 864F1ABB2A964D31009743F2 /* FirebaseStorage */; };
 		B9380F7627E3EEBD00B5C769 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = B9380F7527E3EEBD00B5C769 /* FirebaseAuth */; };
 		B9380F7A27E3FABA00B5C769 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B9380F7927E3FABA00B5C769 /* GoogleService-Info.plist */; };
 		B94D0AC327F5060D00753EEA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B94D0AC227F5060D00753EEA /* Assets.xcassets */; };
@@ -15,7 +18,6 @@
 		B94D0ACC27F506C600753EEA /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B983CA1627F21B1D00E4E201 /* ViewModel.swift */; };
 		B94D0ACD27F506CC00753EEA /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B983CA1827F21B1D00E4E201 /* ContentView.swift */; };
 		B94D0ACF27F5075900753EEA /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = B94D0ACE27F5075900753EEA /* FirebaseAuth */; };
-		B94D0AD127F5075900753EEA /* FirebaseStorageSwift-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = B94D0AD027F5075900753EEA /* FirebaseStorageSwift-Beta */; };
 		B94D0AD227F5157400753EEA /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B9380F7927E3FABA00B5C769 /* GoogleService-Info.plist */; };
 		B94D0AD327F52FBB00753EEA /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B983CA1727F21B1D00E4E201 /* ImagePicker.swift */; };
 		B983CA1927F21B1D00E4E201 /* StorageExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B983CA1527F21B1D00E4E201 /* StorageExampleApp.swift */; };
@@ -24,11 +26,9 @@
 		B983CA1C27F21B1D00E4E201 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B983CA1827F21B1D00E4E201 /* ContentView.swift */; };
 		B9A598C227E3D16A003BCFD0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B9A598C127E3D16A003BCFD0 /* Assets.xcassets */; };
 		B9A598C527E3D16A003BCFD0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B9A598C427E3D16A003BCFD0 /* Preview Assets.xcassets */; };
-		B9CE8D6027F38915002AB1F6 /* FirebaseStorageSwift-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = B9CE8D5F27F38915002AB1F6 /* FirebaseStorageSwift-Beta */; };
 		B9EABE2827FB82B300E055FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B9EABE2727FB82B300E055FD /* Assets.xcassets */; };
 		B9EABE2B27FB82B300E055FD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B9EABE2A27FB82B300E055FD /* Preview Assets.xcassets */; };
 		B9EABE3127FB82CD00E055FD /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = B9EABE3027FB82CD00E055FD /* FirebaseAuth */; };
-		B9EABE3327FB82D400E055FD /* FirebaseStorageSwift-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = B9EABE3227FB82D400E055FD /* FirebaseStorageSwift-Beta */; };
 		B9EABE3427FB83C900E055FD /* StorageExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B983CA1527F21B1D00E4E201 /* StorageExampleApp.swift */; };
 		B9EABE3527FB83CD00E055FD /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B983CA1627F21B1D00E4E201 /* ViewModel.swift */; };
 		B9EABE3627FB83D100E055FD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B983CA1827F21B1D00E4E201 /* ContentView.swift */; };
@@ -60,7 +60,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B94D0ACF27F5075900753EEA /* FirebaseAuth in Frameworks */,
-				B94D0AD127F5075900753EEA /* FirebaseStorageSwift-Beta in Frameworks */,
+				864F1ABA2A964D27009743F2 /* FirebaseStorage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -69,7 +69,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B9380F7627E3EEBD00B5C769 /* FirebaseAuth in Frameworks */,
-				B9CE8D6027F38915002AB1F6 /* FirebaseStorageSwift-Beta in Frameworks */,
+				864F1AB82A964D11009743F2 /* FirebaseStorage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,7 +78,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B9EABE3127FB82CD00E055FD /* FirebaseAuth in Frameworks */,
-				B9EABE3327FB82D400E055FD /* FirebaseStorageSwift-Beta in Frameworks */,
+				864F1ABC2A964D31009743F2 /* FirebaseStorage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -196,7 +196,7 @@
 			name = "StorageExample (macOS)";
 			packageProductDependencies = (
 				B94D0ACE27F5075900753EEA /* FirebaseAuth */,
-				B94D0AD027F5075900753EEA /* FirebaseStorageSwift-Beta */,
+				864F1AB92A964D27009743F2 /* FirebaseStorage */,
 			);
 			productName = "StorageExample (macOS)";
 			productReference = B94D0ABC27F5060C00753EEA /* StorageExample (macOS).app */;
@@ -217,7 +217,7 @@
 			name = "StorageExample (iOS)";
 			packageProductDependencies = (
 				B9380F7527E3EEBD00B5C769 /* FirebaseAuth */,
-				B9CE8D5F27F38915002AB1F6 /* FirebaseStorageSwift-Beta */,
+				864F1AB72A964D11009743F2 /* FirebaseStorage */,
 			);
 			productName = StorageExample;
 			productReference = B9A598BA27E3D169003BCFD0 /* StorageExample (iOS).app */;
@@ -238,7 +238,7 @@
 			name = "StorageExample (tvOS)";
 			packageProductDependencies = (
 				B9EABE3027FB82CD00E055FD /* FirebaseAuth */,
-				B9EABE3227FB82D400E055FD /* FirebaseStorageSwift-Beta */,
+				864F1ABB2A964D31009743F2 /* FirebaseStorage */,
 			);
 			productName = "StorageExample (tvOS)";
 			productReference = B9EABE2127FB82B200E055FD /* StorageExample (tvOS).app */;
@@ -695,13 +695,28 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
 				kind = versionRange;
-				maximumVersion = 10.0.0;
-				minimumVersion = 9.0.0;
+				maximumVersion = 11.0.0;
+				minimumVersion = 10.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		864F1AB72A964D11009743F2 /* FirebaseStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B9380F7427E3EEBD00B5C769 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseStorage;
+		};
+		864F1AB92A964D27009743F2 /* FirebaseStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B9380F7427E3EEBD00B5C769 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseStorage;
+		};
+		864F1ABB2A964D31009743F2 /* FirebaseStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B9380F7427E3EEBD00B5C769 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseStorage;
+		};
 		B9380F7527E3EEBD00B5C769 /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = B9380F7427E3EEBD00B5C769 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
@@ -712,25 +727,10 @@
 			package = B9380F7427E3EEBD00B5C769 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAuth;
 		};
-		B94D0AD027F5075900753EEA /* FirebaseStorageSwift-Beta */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B9380F7427E3EEBD00B5C769 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = "FirebaseStorageSwift-Beta";
-		};
-		B9CE8D5F27F38915002AB1F6 /* FirebaseStorageSwift-Beta */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B9380F7427E3EEBD00B5C769 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = "FirebaseStorageSwift-Beta";
-		};
 		B9EABE3027FB82CD00E055FD /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = B9380F7427E3EEBD00B5C769 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAuth;
-		};
-		B9EABE3227FB82D400E055FD /* FirebaseStorageSwift-Beta */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B9380F7427E3EEBD00B5C769 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = "FirebaseStorageSwift-Beta";
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
- Updated the Firebase Storage quickstart to depend on Firebase 10.x (previously set to 9.x)
- Changed the framework `FirebaseStorageSwift-Beta` to `FirebaseStorage` (this is the Swift implementation in 10.x)