### PR TITLE
Update all quickstarts to iOS 13 minimum

### DIFF
--- a/abtesting/LegacyABTestingQuickstart/Podfile
+++ b/abtesting/LegacyABTestingQuickstart/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 target 'ABTestingExample' do
   use_frameworks!

--- a/admob/Podfile
+++ b/admob/Podfile
@@ -1,5 +1,5 @@
 use_frameworks!
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 pod 'FirebaseAnalytics'
 pod 'Google-Mobile-Ads-SDK', '> 9.0'

--- a/analytics/LegacyAnalyticsQuickstart/Podfile
+++ b/analytics/LegacyAnalyticsQuickstart/Podfile
@@ -1,7 +1,7 @@
 # AnalyticsExample
 
 use_frameworks!
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 target 'AnalyticsExample' do
   pod 'FirebaseAnalytics'

--- a/appdistribution/Podfile
+++ b/appdistribution/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
- platform :ios, '11.0'
+ platform :ios, '13.0'
 
 target 'AppDistributionExample' do
   # Comment the next line if you don't want to use dynamic frameworks

--- a/authentication/LegacyAuthQuickstart/Podfile
+++ b/authentication/LegacyAuthQuickstart/Podfile
@@ -1,7 +1,7 @@
 # AuthenticationExample
 
 use_frameworks!
-platform :ios, '11.0'
+platform :ios, '13.0'
 pod 'FirebaseAnalytics'
 # [START auth_pod]
 pod 'FirebaseAuth'

--- a/config/LegacyConfigQuickstart/Podfile
+++ b/config/LegacyConfigQuickstart/Podfile
@@ -1,6 +1,6 @@
 # ConfigExample
 use_frameworks!
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 pod 'FirebaseRemoteConfig'
 

--- a/crashlytics/LegacyCrashlyticsQuickstart/Podfile
+++ b/crashlytics/LegacyCrashlyticsQuickstart/Podfile
@@ -1,6 +1,6 @@
 # CrashlyticsExample
 use_frameworks!
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 target 'CrashlyticsExample'  do
   pod 'FirebaseCrashlytics'

--- a/database/Podfile
+++ b/database/Podfile
@@ -1,7 +1,7 @@
 # DatabaseExample
 
 use_frameworks!
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 def firebase_pods
   pod 'FirebaseAuth'

--- a/dynamiclinks/Podfile
+++ b/dynamiclinks/Podfile
@@ -1,7 +1,7 @@
 # DynamicLinksExample
 
 use_frameworks!
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 # [START pod_ddl]
 pod 'FirebaseAnalytics'

--- a/functions/LegacyFunctionsQuickstart/Podfile
+++ b/functions/LegacyFunctionsQuickstart/Podfile
@@ -1,7 +1,7 @@
 # FunctionsExample
 
 use_frameworks!
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 pod 'FirebaseAnalytics'
 pod 'FirebaseAuth'

--- a/inappmessaging/Podfile
+++ b/inappmessaging/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 use_frameworks!
 

--- a/installations/Podfile
+++ b/installations/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '13.0'
 use_frameworks!
 
 pod 'FirebaseInstallations'

--- a/messaging/Podfile
+++ b/messaging/Podfile
@@ -1,7 +1,7 @@
 # Firebase Cloud Messaging (FCM)
 
 use_frameworks!
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 def firebase_pods
   pod 'FirebaseAnalytics'

--- a/performance/Podfile
+++ b/performance/Podfile
@@ -1,6 +1,6 @@
 # PerformanceExample
 use_frameworks!
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 pod 'FirebaseAnalytics'
 pod 'FirebasePerformance'

--- a/storage/LegacyStorageQuickstart/Podfile
+++ b/storage/LegacyStorageQuickstart/Podfile
@@ -1,7 +1,7 @@
 # StorageExample
 
 use_frameworks!
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 pod 'FirebaseAuth'
 pod 'FirebaseStorage'

--- a/template/clone.sh
+++ b/template/clone.sh
@@ -128,7 +128,7 @@ grep $SOURCE -R . && {
 echo "Creating Podfile..."
 echo "# $DEST" > Podfile
 echo "use_frameworks!" >> Podfile
-echo "platform :ios, '11.0'" >> Podfile
+echo "platform :ios, '13.0'" >> Podfile
 if [[ -n "${POD}" ]]; then
   echo "Including pod: $POD"
   echo "pod '$POD'" >> Podfile


### PR DESCRIPTION
- New projects should have at least an iOS 13 minimum
- Prepare for integration testing for next major Firebase release that will require iOS 13