### PR TITLE
[Storage] Standardize Firebase's dependency rules with other QS apps

### DIFF
--- a/storage/StorageExample/StorageExample.xcodeproj/project.pbxproj
+++ b/storage/StorageExample/StorageExample.xcodeproj/project.pbxproj
@@ -694,8 +694,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
-				kind = versionRange;
-				maximumVersion = 11.0.0;
+				kind = upToNextMajorVersion;
 				minimumVersion = 10.0.0;
 			};
 		};


### PR DESCRIPTION
Rather than use a version range, prefer `upToNextMajorVersion` so a single grep and replace can work for when we update QSs for a major version update.