### PR TITLE
[NFC] Remove TODOs about Xcode 13

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -56,7 +56,6 @@ jobs:
     runs-on: macOS-12
     strategy:
       matrix:
-        # TODO investigate tvOS Xcode 13.1 test failure.
         xcode: ["14.2"]
         os: [iOS, tvOS, macOS]
         include:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -60,7 +60,6 @@ jobs:
     runs-on: macOS-12
     strategy:
       matrix:
-        # TODO investigate tvOS Xcode 13.1 test failure.
         xcode: ["14.2"]
         os: [iOS, tvOS]
         include:


### PR DESCRIPTION
Xcode 13 is no longer supported so these TODOs about it are now irrelevant.