### PR TITLE
Add code signing note in build-for-testing.sh

### DIFF
--- a/scripts/build-for-testing.sh
+++ b/scripts/build-for-testing.sh
@@ -83,6 +83,7 @@ if [[ "$SAMPLE" == Config ]];then
     flags+=( -configuration Debug )
 fi
 
+# NOTE: Add your code signature details here for running tests in Firebase Test Lab
 flags+=(
     CODE_SIGN_IDENTITY=""
     CODE_SIGNING_REQUIRED=NO


### PR DESCRIPTION
Code signing is required to run tests in Firebase Test Lab. This PR makes this more explicit in the `build-for-testing.sh` script.