### PR TITLE
[Infra] Embed frameworks in Frameworks dir

### DIFF
--- a/scripts/add_framework_script.rb
+++ b/scripts/add_framework_script.rb
@@ -65,6 +65,7 @@ if File.directory?(framework_path)
       framework_set = project_target.frameworks_build_phase.files.to_set
       puts "The following frameworks are added to #{project_target}"
       embed_frameworks_phase = project_target.new_copy_files_build_phase("Embed Frameworks")
+      embed_frameworks_phase.dst_subfolder_spec = "10" # `Frameworks` directory
       framework_group.each do |framework|
         next if framework_set.size == framework_set.add(framework).size
         add_ref(project_framework_group,


### PR DESCRIPTION
By default, they are embedded to the `Resources` directory in the app bundle (which is at the root of the app). To mirror what zip customers would be doing, they should be embedded in the `Frameworks` directory. This didn't cause any errors, but likely would if we were shipping dynamic frameworks.