### PR TITLE
Remove FDL SDK usage from Auth QS

### DIFF
--- a/.github/workflows/authentication.yml
+++ b/.github/workflows/authentication.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-12
+    runs-on: macOS-14
     env:
       SPM: false
       LEGACY: false
@@ -35,9 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
-      # Facebook SDK requires Xcode 14
-      - name: Xcode 14.1
-        run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
+      - name: Xcode 15.3
+        run: sudo xcode-select -s /Applications/Xcode_15.3.app/Contents/Developer
         
       - name: Setup
         run: |

--- a/authentication/AuthenticationExample/SceneDelegate.swift
+++ b/authentication/AuthenticationExample/SceneDelegate.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import UIKit
-import FirebaseDynamicLinks
 import FirebaseAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -58,21 +57,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   // MARK: - Firebase 🔥
 
   private func handleIncomingDynamicLink(_ incomingURL: URL) {
-    DynamicLinks.dynamicLinks().handleUniversalLink(incomingURL) { dynamicLink, error in
-      guard error == nil else {
-        return print("ⓧ Error in \(#function): \(error!.localizedDescription)")
-      }
 
-      guard let link = dynamicLink?.url?.absoluteString else { return }
+    let link = incomingURL.absoluteString
 
-      if Auth.auth().isSignIn(withEmailLink: link) {
-        // Save the link as it will be used in the next step to complete login
-        UserDefaults.standard.set(link, forKey: "Link")
+    if Auth.auth().isSignIn(withEmailLink: link) {
+      // Save the link as it will be used in the next step to complete login
+      UserDefaults.standard.set(link, forKey: "Link")
 
-        // Post a notification to the PasswordlessViewController to resume authentication
-        NotificationCenter.default
-          .post(Notification(name: Notification.Name("PasswordlessEmailNotificationSuccess")))
-      }
+      // Post a notification to the PasswordlessViewController to resume authentication
+      NotificationCenter.default
+        .post(Notification(name: Notification.Name("PasswordlessEmailNotificationSuccess")))
     }
   }
 

--- a/authentication/AuthenticationExample/SceneDelegate.swift
+++ b/authentication/AuthenticationExample/SceneDelegate.swift
@@ -57,7 +57,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   // MARK: - Firebase 🔥
 
   private func handleIncomingDynamicLink(_ incomingURL: URL) {
-
     let link = incomingURL.absoluteString
 
     if Auth.auth().isSignIn(withEmailLink: link) {

--- a/authentication/AuthenticationExample/ViewControllers/OtherAuthMethodControllers/PasswordlessViewController.swift
+++ b/authentication/AuthenticationExample/ViewControllers/OtherAuthMethodControllers/PasswordlessViewController.swift
@@ -35,7 +35,9 @@ class PasswordlessViewController: OtherAuthViewController {
 
   private func sendSignInLink(to email: String) {
     let actionCodeSettings = ActionCodeSettings()
-    let stringURL = "https://\(authorizedDomain).firebaseapp.com/login?email=\(email)"
+
+    // Update "demo" to match the path defined in the dynamic link.
+    let stringURL = "https://\(authorizedDomain)/demo"
     actionCodeSettings.url = URL(string: stringURL)
     // The sign-in operation must be completed in the app.
     actionCodeSettings.handleCodeInApp = true
@@ -46,6 +48,7 @@ class PasswordlessViewController: OtherAuthViewController {
 
       // Set `email` property as it will be used to complete sign in after opening email link
       self.email = email
+      print("successfully sent email")
     }
   }
 

--- a/authentication/Podfile
+++ b/authentication/Podfile
@@ -9,9 +9,6 @@ target 'AuthenticationExample' do
   ## Firebase 🔥 Pods
   pod 'FirebaseAnalytics'
   pod 'FirebaseAuth'
-  
-  ### For Email Link/Passwordless Auth
-  pod 'FirebaseDynamicLinks'
 
   ## Pod for Sign in with Google
   pod 'GoogleSignIn'

--- a/authentication/Podfile.lock
+++ b/authentication/Podfile.lock
@@ -5,16 +5,16 @@ PODS:
   - AppAuth/Core (1.7.5)
   - AppAuth/ExternalUserAgent (1.7.5):
     - AppAuth/Core
-  - FBAEMKit (17.0.0):
-    - FBSDKCoreKit_Basics (= 17.0.0)
-  - FBSDKCoreKit (17.0.0):
-    - FBAEMKit (= 17.0.0)
-    - FBSDKCoreKit_Basics (= 17.0.0)
-  - FBSDKCoreKit_Basics (17.0.0)
-  - FBSDKLoginKit (17.0.0):
-    - FBSDKCoreKit (= 17.0.0)
-  - FirebaseAnalytics (10.24.0):
-    - FirebaseAnalytics/AdIdSupport (= 10.24.0)
+  - FBAEMKit (17.0.1):
+    - FBSDKCoreKit_Basics (= 17.0.1)
+  - FBSDKCoreKit (17.0.1):
+    - FBAEMKit (= 17.0.1)
+    - FBSDKCoreKit_Basics (= 17.0.1)
+  - FBSDKCoreKit_Basics (17.0.1)
+  - FBSDKLoginKit (17.0.1):
+    - FBSDKCoreKit (= 17.0.1)
+  - FirebaseAnalytics (10.25.0):
+    - FirebaseAnalytics/AdIdSupport (= 10.25.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
@@ -22,51 +22,49 @@ PODS:
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (10.24.0):
+  - FirebaseAnalytics/AdIdSupport (10.25.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
-    - GoogleAppMeasurement (= 10.24.0)
+    - GoogleAppMeasurement (= 10.25.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseAppCheckInterop (10.24.0)
-  - FirebaseAuth (10.24.0):
+  - FirebaseAppCheckInterop (10.25.0)
+  - FirebaseAuth (10.25.0):
     - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseCore (10.24.0):
+  - FirebaseCore (10.25.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreInternal (10.24.0):
+  - FirebaseCoreInternal (10.25.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseDynamicLinks (10.24.0):
-    - FirebaseCore (~> 10.0)
-  - FirebaseInstallations (10.24.0):
+  - FirebaseInstallations (10.25.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - GoogleAppMeasurement (10.24.0):
-    - GoogleAppMeasurement/AdIdSupport (= 10.24.0)
+  - GoogleAppMeasurement (10.25.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.25.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (10.24.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.24.0)
+  - GoogleAppMeasurement/AdIdSupport (10.25.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.25.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (10.24.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.25.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
@@ -76,32 +74,32 @@ PODS:
     - AppAuth (< 2.0, >= 1.7.3)
     - GTMAppAuth (< 5.0, >= 4.1.1)
     - GTMSessionFetcher/Core (~> 3.3)
-  - GoogleUtilities/AppDelegateSwizzler (7.13.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.13.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (7.13.0):
+  - GoogleUtilities/Environment (7.13.2):
     - GoogleUtilities/Privacy
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.13.0):
+  - GoogleUtilities/Logger (7.13.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/MethodSwizzler (7.13.0):
+  - GoogleUtilities/MethodSwizzler (7.13.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (7.13.0):
+  - GoogleUtilities/Network (7.13.2):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.13.0)":
+  - "GoogleUtilities/NSData+zlib (7.13.2)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (7.13.0)
-  - GoogleUtilities/Reachability (7.13.0):
+  - GoogleUtilities/Privacy (7.13.2)
+  - GoogleUtilities/Reachability (7.13.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/UserDefaults (7.13.0):
+  - GoogleUtilities/UserDefaults (7.13.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - GTMAppAuth (4.1.1):
@@ -120,7 +118,6 @@ DEPENDENCIES:
   - FBSDKLoginKit
   - FirebaseAnalytics
   - FirebaseAuth
-  - FirebaseDynamicLinks
   - GoogleSignIn
 
 SPEC REPOS:
@@ -135,7 +132,6 @@ SPEC REPOS:
     - FirebaseAuth
     - FirebaseCore
     - FirebaseCoreInternal
-    - FirebaseDynamicLinks
     - FirebaseInstallations
     - GoogleAppMeasurement
     - GoogleSignIn
@@ -148,26 +144,25 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AppAuth: 501c04eda8a8d11f179dbe8637b7a91bb7e5d2fa
-  FBAEMKit: 31a20c2d8744d8c57d3a5b7ae4e27b4fdd819193
-  FBSDKCoreKit: dac911b656816f8d0b06e5fa4bac60e89505bb3b
-  FBSDKCoreKit_Basics: 92b7b7458d57091370b0b6cc197578874c3b4b16
-  FBSDKLoginKit: 5d5271ebfd1e39c6b071de8db5c4bd6255be3561
-  FirebaseAnalytics: b5efc493eb0f40ec560b04a472e3e1a15d39ca13
-  FirebaseAppCheckInterop: fecc08c89936c8acb1428d8088313aabedb348e4
-  FirebaseAuth: 711d01cccefaf10035b3090a92956d0dd4f99088
-  FirebaseCore: 11dc8a16dfb7c5e3c3f45ba0e191a33ac4f50894
-  FirebaseCoreInternal: bcb5acffd4ea05e12a783ecf835f2210ce3dc6af
-  FirebaseDynamicLinks: 96e59750f0c383258c35f5b20e3c18e14b57933a
-  FirebaseInstallations: 8f581fca6478a50705d2bd2abd66d306e0f5736e
-  GoogleAppMeasurement: f3abf08495ef2cba7829f15318c373b8d9226491
+  FBAEMKit: 97eaf41451b49691447df831f7f425229ae64b66
+  FBSDKCoreKit: e34084567d11cfdd4787ace2b1a0255bedf34ade
+  FBSDKCoreKit_Basics: 3d78e5fe00504e5c1aed1c48de0654c3a1565d15
+  FBSDKLoginKit: 9a581053879a1e6fc3fab8ead341c78c6a318255
+  FirebaseAnalytics: ec00fe8b93b41dc6fe4a28784b8e51da0647a248
+  FirebaseAppCheckInterop: 5da5ce93e8797a215e3f677fb0654b74e736c8b8
+  FirebaseAuth: c0f93dcc570c9da2bffb576969d793e95c344fbb
+  FirebaseCore: 7ec4d0484817f12c3373955bc87762d96842d483
+  FirebaseCoreInternal: 910a81992c33715fec9263ca7381d59ab3a750b7
+  FirebaseInstallations: 91950fe859846fff0fbd296180909dd273103b09
+  GoogleAppMeasurement: 9abf64b682732fed36da827aa2a68f0221fd2356
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
-  GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152
+  GoogleUtilities: c56430aef51a1aa57b25da78c3f8397e522c67b7
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 8000756fc1c19d2e5697b90311f7832d2e33f6cd
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
 
-PODFILE CHECKSUM: 10d6cbbf1f0fad7683646923bb534d939adf5a3a
+PODFILE CHECKSUM: 3fec667dd6bd8b6be4c37a6eac284e979d933bcd
 
 COCOAPODS: 1.15.2

--- a/authentication/README.md
+++ b/authentication/README.md
@@ -188,8 +188,6 @@ See the [Getting Started with Password-based Sign In guide](https://firebase.goo
 
 Email Link authentication, which is also referred to as Passwordless authentication, works by sending a verification email to a user requesting to sign in. This verification email contains a special **Dynamic Link** that links the user back to your app, completing authentication in the process. In order to configure this method of authentication, we will use [Firebase Dynamic Links](https://firebase.google.com/docs/dynamic-links), which we will need to set up.
 
-If this is your first time working with Dynamic Links, here's a great [introduction video](https://www.youtube.com/watch?v=KLBjAg6HvG0) from Firebase's Firecast series on YouTube. Note, we will outline most of the steps covered in this tutorial below!
-
 #### Start by going to the [Firebase Console](https://console.firebase.google.com) and navigate to your project:
   - Select the **Auth** panel and then click the **Sign In Method** tab.
   - Click **Email/Password** and ensure it is enabled.
@@ -208,14 +206,14 @@ As we mentioned above, we will need to configure dynamic links for this auth flo
     - Setup your short URL. Feel free to put whatever here, like "demo", "login, or "passwordless" for example. Click **Next**.
     - For the Deep Link URL, configure the URL to look like:
     >        https://[insert an authorized domain]/login?email=email
-    >For the authorized domain ⬆, go to the the Authentication tab, then click the "Sign-in method", and scroll down to the "Authorized domains" section. Copy the domain that looks like `[the app's name].firebaseapp.com`. Paste this entire domain into the Deep Link we are creating above. You can also instead allowlist the dynamic links URL prefix and use that here as well.
+    >For the authorized domain ⬆, go to the the Authentication tab, then click the "Settings" tab, and select the "Authorized domains" section. Copy the domain that looks like `[the app's name].firebaseapp.com`. Paste this entire domain into the Deep Link we are creating above. You can also instead allowlist the dynamic links URL prefix and use that here as well.
     - On step 3, **Define link behavior for iOS**, select **Open the deep link in your iOS App** and make sure your app is selected in the drop down.
     - Configure the following steps as you please and then hit **Create**!
 
   - Dynamic links use your app's bundle identifier as a url scheme by default. In Xcode, [add a custom URL scheme for your **bundle identifier**](https://developers.google.com/identity/sign-in/ios/start-integrating#add_a_url_scheme_to_your_project).
   - Last todo! Navigate to [`sendSignInLink()`](https://github.com/firebase/quickstart-ios/blob/main/authentication/AuthenticationExample/View%20Controllers/Other%20Auth%20Method%20Controllers/PasswordlessViewController.swift#L39) in [`PasswordlessViewController.swift`](https://github.com/firebase/quickstart-ios/blob/main/authentication/AuthenticationExample/View%20Controllers/Other%20Auth%20Method%20Controllers/PasswordlessViewController.swift). Within the method, there is a `stringURL` constant. Paste in the long deeplink you created from the steps above for the `authroizedDomain` property above the method. It should look something like:
 ```swift
-    let stringURL = "https://\(authorizedDomain).firebaseapp.com/login?email=\(email)"
+    let stringURL = "https://\(authorizedDomain)/login"
 ```
 
 - Run the app on your device or simulator.
@@ -241,11 +239,9 @@ When the user receives the verification email, they can open the link contained 
 
 private func handleIncomingDynamicLink(_ incomingURL: URL) {
 
-    DynamicLinks.dynamicLinks().handleUniversalLink(incomingURL) { (dynamicLink, error) in
-
     // Handle the potential `error`
 
-    guard let link = dynamicLink?.url?.absoluteString else { return }
+    let link = incomingURL.absoluteString
 
     // Here, we check if our dynamic link is a sign-link (the one we emailed our user!)
     if Auth.auth().isSignIn(withEmailLink: link) {
@@ -255,7 +251,6 @@ private func handleIncomingDynamicLink(_ incomingURL: URL) {
 
         // Post a notification to the PasswordlessViewController to resume authentication
         NotificationCenter.default.post(Notification(name: Notification.Name("PasswordlessEmailNotificationSuccess")))
-        }
     }
 }
 ```


### PR DESCRIPTION
The Auth sample should depend on the FDL service but not the FDL SDK

Port changes from https://github.com/firebase/firebase-ios-sdk/pull/12864