### PR TITLE
[Vertex AI] Update README link to point to `main`

### DIFF
--- a/vertexai/README.md
+++ b/vertexai/README.md
@@ -1,5 +1,5 @@
 # Vertex AI for Firebase Quickstart
 
 Try out the
-[Vertex AI for Firebase Sample App](https://github.com/firebase/firebase-ios-sdk/tree/release-10.26/FirebaseVertexAI/Sample)
+[Vertex AI for Firebase Sample App](https://github.com/firebase/firebase-ios-sdk/tree/main/FirebaseVertexAI/Sample)
 in the `firebase-ios-sdk` repository to get started.


### PR DESCRIPTION
Updated the Vertex AI README to link to https://github.com/firebase/firebase-ios-sdk/tree/main/FirebaseVertexAI/Sample now that it has been merged into `main` (https://github.com/firebase/firebase-ios-sdk/pull/12955).