### PR TITLE
AuthAI no longer transitively imports Auth

### DIFF
--- a/firestore/FirestoreExample/RestaurantsTableViewController.swift
+++ b/firestore/FirestoreExample/RestaurantsTableViewController.swift
@@ -16,6 +16,7 @@
 
 import UIKit
 import FirebaseFirestore
+import FirebaseAuth
 import FirebaseAuthUI
 import FirebaseEmailAuthUI
 import SDWebImage


### PR DESCRIPTION
With Firebase 11 and FirebaseUI 14, importing AuthUI no longer transitively imports Auth.

See https://github.com/firebase/firebase-ios-sdk/actions/runs/10381722483/job/28746515460

and  https://github.com/firebase/FirebaseUI-iOS/issues/1196#issuecomment-2288141876