### PR TITLE
Run CI on macOS 15 with the iPhone 16 simulator

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: macOS-15
     strategy:
       matrix:
-        xcode: ["15.3"]
+        xcode: ["16.1"]
         os: [iOS, tvOS, macOS, watchOS, catalyst]
         include:
           - os: iOS

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -33,7 +33,7 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       SPM: false
       TEST: true
@@ -55,17 +55,17 @@ jobs:
           LEGACY: true
           SWIFT_SUFFIX: ""
           OS: iOS
-          DEVICE: iPhone 14
+          DEVICE: iPhone 16
   spm:
     name: spm (Xcode ${{ matrix.xcode }} - ${{ matrix.os }})
-    runs-on: macOS-14
+    runs-on: macOS-15
     strategy:
       matrix:
         xcode: ["15.3"]
         os: [iOS, tvOS, macOS, watchOS, catalyst]
         include:
           - os: iOS
-            device: iPhone 15
+            device: iPhone 16
             # Test runs locally but fails in CI with:
             # (Underlying Error: lstat of
             # /Users/runner/Library/Developer/CoreSimulator/Devices/

--- a/.github/workflows/admob.yml
+++ b/.github/workflows/admob.yml
@@ -29,12 +29,12 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       SPM: false
       LEGACY: false
       OS: iOS
-      DEVICE: iPhone 14
+      DEVICE: iPhone 16
       TEST: false
     steps:
       - name: Checkout

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -29,14 +29,14 @@ env:
 jobs:
   cocoapods:
     name: cocoapods - ${{ matrix.os }}
-    runs-on: macOS-14
+    runs-on: macOS-15
     strategy:
       matrix:
         os: [iOS, catalyst, tvOS, macOS]
         xcode: ["15.3"]
         include:
           - os: iOS
-            device: iPhone 14
+            device: iPhone 16
           - os: catalyst
             device: localhost
           - os: tvOS

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [iOS, catalyst, tvOS, macOS]
-        xcode: ["15.3"]
+        xcode: ["16.1"]
         include:
           - os: iOS
             device: iPhone 16

--- a/.github/workflows/authentication.yml
+++ b/.github/workflows/authentication.yml
@@ -29,12 +29,12 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       SPM: false
       LEGACY: false
       OS: iOS
-      DEVICE: iPhone 14
+      DEVICE: iPhone 16
       TEST: false
     steps:
       - name: Checkout

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   check:
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       MINT_PATH: ${{ github.workspace }}/mint
     steps:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       SPM: false
       LEGACY: false
@@ -46,9 +46,9 @@ jobs:
           gem install xcpretty
           bundle exec pod install --repo-update
           ../scripts/install_prereqs/config.sh
-          xcrun simctl boot "iPhone 14"
+          xcrun simctl boot "iPhone 16"
       - name: Build Swift
         run: ./scripts/test.sh
         env:
           OS: iOS
-          DEVICE: iPhone 14
+          DEVICE: iPhone 16

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -29,12 +29,12 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       SPM: false
       LEGACY: true
       OS: iOS
-      DEVICE: iPhone 14
+      DEVICE: iPhone 16
       TEST: true
     steps:
       - name: Checkout
@@ -54,14 +54,14 @@ jobs:
           SWIFT_SUFFIX: Swift
   spm:
     name: spm (Xcode ${{ matrix.xcode }} - ${{ matrix.os }})
-    runs-on: macOS-14
+    runs-on: macOS-15
     strategy:
       matrix:
         xcode: ["15.3"]
         os: [iOS, tvOS, macOS, watchOS]
         include:
           - os: iOS
-            device: iPhone 14
+            device: iPhone 16
             test: false # flaky
           - os: tvOS
             device: Apple TV 4K (3rd generation) (at 1080p)

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: macOS-15
     strategy:
       matrix:
-        xcode: ["15.3"]
+        xcode: ["16.1"]
         os: [iOS, tvOS, macOS, watchOS]
         include:
           - os: iOS

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -29,12 +29,12 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       SPM: false
       LEGACY: false
       OS: iOS
-      DEVICE: iPhone 14
+      DEVICE: iPhone 16
       TEST: false
     steps:
       - name: Checkout
@@ -53,14 +53,14 @@ jobs:
           SWIFT_SUFFIX: Swift
   spm:
     name: spm (Xcode ${{ matrix.xcode }} - ${{ matrix.os }})
-    runs-on: macOS-14
+    runs-on: macOS-15
     strategy:
       matrix:
         xcode: ["15.3"]
         os: [iOS, tvOS, macOS]
         include:
           - os: iOS
-            device: iPhone 14
+            device: iPhone 16
             test: false
           - os: tvOS
             device: Apple TV 4K (3rd generation) (at 1080p)

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: macOS-15
     strategy:
       matrix:
-        xcode: ["15.3"]
+        xcode: ["16.1"]
         os: [iOS, tvOS, macOS]
         include:
           - os: iOS

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -29,12 +29,12 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       SPM: false
       LEGACY: false
       OS: iOS
-      DEVICE: iPhone 14
+      DEVICE: iPhone 16
       TEST: true
     steps:
       - name: Checkout

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -29,12 +29,12 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       SPM: false
       LEGACY: false
       OS: iOS
-      DEVICE: iPhone 14
+      DEVICE: iPhone 16
       TEST: false
     steps:
       - name: Checkout

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: macOS-15
     strategy:
       matrix:
-        xcode: ["15.3"]
+        xcode: ["16.1"]
         os: [iOS, tvOS, macOS]
         include:
           - os: iOS

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -29,14 +29,14 @@ env:
 jobs:
   spm:
     name: spm (Xcode ${{ matrix.xcode }} - ${{ matrix.os }})
-    runs-on: macOS-14
+    runs-on: macOS-15
     strategy:
       matrix:
         xcode: ["15.3"]
         os: [iOS, tvOS, macOS]
         include:
           - os: iOS
-            device: iPhone 14
+            device: iPhone 16
           - os: tvOS
             device: Apple TV 4K (3rd generation) (at 1080p)
           - os: macOS

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -29,12 +29,12 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       SPM: false
       LEGACY: false
       OS: iOS
-      DEVICE: iPhone 14
+      DEVICE: iPhone 16
       TEST: true
     steps:
       - name: Checkout

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -29,12 +29,12 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       SPM: false
       LEGACY: false
       OS: iOS
-      DEVICE: iPhone 14
+      DEVICE: iPhone 16
       TEST: true
     steps:
       - name: Checkout

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -29,12 +29,12 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       SPM: false
       LEGACY: false
       OS: iOS
-      DEVICE: iPhone 14
+      DEVICE: iPhone 16
       TEST: false
     steps:
       - name: Checkout

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -33,12 +33,12 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       SPM: false
       LEGACY: false
       OS: iOS
-      DEVICE: iPhone 14
+      DEVICE: iPhone 16
       TEST: true
     steps:
       - name: Checkout
@@ -57,14 +57,14 @@ jobs:
           SWIFT_SUFFIX: Swift
   spm:
     name: spm (Xcode ${{ matrix.xcode }} - ${{ matrix.os }})
-    runs-on: macOS-14
+    runs-on: macOS-15
     strategy:
       matrix:
         xcode: ["15.3"]
         os: [iOS, tvOS]
         include:
           - os: iOS
-            device: iPhone 14
+            device: iPhone 16
             test: false
           - os: tvOS
             device: Apple TV 4K (3rd generation) (at 1080p)

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: macOS-15
     strategy:
       matrix:
-        xcode: ["15.3"]
+        xcode: ["16.1"]
         os: [iOS, tvOS]
         include:
           - os: iOS

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -29,12 +29,12 @@ env:
 jobs:
   cocoapods:
     name: cocoapods
-    runs-on: macOS-14
+    runs-on: macOS-15
     env:
       SPM: false
       LEGACY: true
       OS: iOS
-      DEVICE: iPhone 14
+      DEVICE: iPhone 16
       TEST: true
     steps:
       - name: Checkout
@@ -55,14 +55,14 @@ jobs:
 
   spm:
     name: spm (Xcode ${{ matrix.xcode }} - ${{ matrix.os }})
-    runs-on: macOS-14
+    runs-on: macOS-15
     strategy:
       matrix:
         xcode: ["15.3"]
         os: [iOS, tvOS, macOS]
         include:
           - os: iOS
-            device: iPhone 14
+            device: iPhone 16
           - os: tvOS
             device: Apple TV 4K (3rd generation) (at 1080p)
           - os: macOS

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: macOS-15
     strategy:
       matrix:
-        xcode: ["15.3"]
+        xcode: ["16.1"]
         os: [iOS, tvOS, macOS]
         include:
           - os: iOS

--- a/scripts/build-for-testing.sh
+++ b/scripts/build-for-testing.sh
@@ -100,7 +100,7 @@ function xcb() {
 }
 
 # Run xcodebuild
-sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
 xcb "${flags[@]}"
 echo "$message"
 

--- a/scripts/framework_test.sh
+++ b/scripts/framework_test.sh
@@ -38,7 +38,7 @@ if [[ "$have_secrets" == true ]]; then
     xcodebuild \
     -project ${SAMPLE}Example.xcodeproj \
     -scheme  ${SAMPLE}Example${SWIFT_SUFFIX} \
-    -destination 'platform=iOS Simulator,name=iPhone 14 Pro' "OTHER_LDFLAGS=\$(OTHER_LDFLAGS) -ObjC" "FRAMEWORK_SEARCH_PATHS= \$(PROJECT_DIR)/Firebase/" HEADER_SEARCH_PATHS='$(PROJECT_DIR)/Firebase' \
+    -destination 'platform=iOS Simulator,name=iPhone 16 Pro' "OTHER_LDFLAGS=\$(OTHER_LDFLAGS) -ObjC" "FRAMEWORK_SEARCH_PATHS= \$(PROJECT_DIR)/Firebase/" HEADER_SEARCH_PATHS='$(PROJECT_DIR)/Firebase' \
     build \
     test \
     ) || EXIT_STATUS=$?
@@ -48,7 +48,7 @@ else
     xcodebuild \
     -project ${SAMPLE}Example.xcodeproj \
     -scheme  ${SAMPLE}Example${SWIFT_SUFFIX} \
-    -destination 'platform=iOS Simulator,name=iPhone 14 Pro' "OTHER_LDFLAGS=\$(OTHER_LDFLAGS) -ObjC" "FRAMEWORK_SEARCH_PATHS= \$(PROJECT_DIR)/Firebase/" HEADER_SEARCH_PATHS='$(PROJECT_DIR)/Firebase' \
+    -destination 'platform=iOS Simulator,name=iPhone 16 Pro' "OTHER_LDFLAGS=\$(OTHER_LDFLAGS) -ObjC" "FRAMEWORK_SEARCH_PATHS= \$(PROJECT_DIR)/Firebase/" HEADER_SEARCH_PATHS='$(PROJECT_DIR)/Firebase' \
     build
     ) || EXIT_STATUS=$?
 fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -31,7 +31,7 @@ if [[ -z "${SPM:-}" ]]; then
 fi
 if [[ -z "${OS:-}" ]]; then
     OS=iOS
-    DEVICE="iPhone 14"
+    DEVICE="iPhone 16"
     echo "Defaulting to OS=$OS"
     echo "Defaulting to DEVICE=$DEVICE"
 fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -123,6 +123,6 @@ function xcb() {
 }
 
 # Run xcodebuild
-sudo xcode-select -s /Applications/Xcode_16.app/Contents/Developer
+sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
 xcb "${flags[@]}"
 echo "$message"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -77,7 +77,7 @@ elif [[ "$OS" == tvOS ]]; then
     DESTINATION="platform=tvOS Simulator,name=${DEVICE}"
     flags+=( -destination "$DESTINATION" )
 elif [[ "$OS" == macOS || "$OS" == catalyst ]]; then
-    DESTINATION="platform=macos"
+    DESTINATION="platform=macOS"
     flags+=( -destination "$DESTINATION" )
 elif [[ "$OS" == watchOS ]]; then
     DESTINATION="platform=watchOS Simulator,name=${DEVICE}"


### PR DESCRIPTION
Updated the CI workflows to use `macos-15`, `Xcode_16.1` and the `iPhone 16` simulator. Xcode 16.x is no longer available in `macos-14` GitHub runner images (https://github.com/actions/runner-images/issues/10703).