### PR TITLE
[CI] Select Xcode and Simulator version based available version

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,6 +20,15 @@
 
 set -euo pipefail
 
+macos_version=$(sw_vers --productVersion)
+if [[ "$macos_version" -ge 15 ]]; then
+    xcode_version="16.1"
+    iphone_version="16"
+else
+    xcode_version="15.3"
+    iphone_version="15"
+fi
+
 # Set default parameters
 if [[ -z "${SPM:-}" ]]; then
     SPM=false
@@ -31,7 +40,7 @@ if [[ -z "${SPM:-}" ]]; then
 fi
 if [[ -z "${OS:-}" ]]; then
     OS=iOS
-    DEVICE="iPhone 16"
+    DEVICE="iPhone ${iphone_version}"
     echo "Defaulting to OS=$OS"
     echo "Defaulting to DEVICE=$DEVICE"
 fi
@@ -123,6 +132,6 @@ function xcb() {
 }
 
 # Run xcodebuild
-sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+sudo xcode-select -s "/Applications/Xcode_${xcode_version}.app/Contents/Developer"
 xcb "${flags[@]}"
 echo "$message"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,8 +20,7 @@
 
 set -euo pipefail
 
-macos_version=$(sw_vers --productVersion)
-if [[ "$macos_version" -ge 15 ]]; then
+if [ -d "/Applications/Xcode_16.1.app" ]; then
     xcode_version="16.1"
     iphone_version="16"
 else


### PR DESCRIPTION
Updated `test.sh` to select Xcode 16.1 if the `/Applications/Xcode_16.1.app` directory exists, otherwise defaults to Xcode 15.3 (picked to match FTL https://github.com/firebase/quickstart-ios/pull/1651); if neither are available, CI will fail. The default iPhone simulator version is selected to match Xcode.