### PR TITLE
Update Firebase AI backend selection strings

### DIFF
--- a/firebaseai/FirebaseAISample/ContentView.swift
+++ b/firebaseai/FirebaseAISample/ContentView.swift
@@ -16,8 +16,8 @@ import SwiftUI
 import FirebaseAI
 
 enum BackendOption: String, CaseIterable, Identifiable {
-  case googleAI = "Google AI"
-  case vertexAI = "Vertex AI"
+  case googleAI = "Gemini Developer API"
+  case vertexAI = "Vertex AI Gemini API"
   var id: String { rawValue }
 
   var backendValue: FirebaseAI {


### PR DESCRIPTION
Renames the UI options for selecting the AI backend in the Firebase AI sample app.

- "Google AI" is changed to "Gemini Developer API"
- "Vertex AI" is changed to "Vertex AI Gemini API"

This aligns the UI with the latest product branding. The underlying enum cases (`googleAI`, `vertexAI`) and their mapping to the backend services remain unchanged.