### PR TITLE
[firebaseai] Fix SPM build for pre-released analytics

### DIFF
--- a/.github/workflows/firebaseai.yml
+++ b/.github/workflows/firebaseai.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
     - 'firebaseai/**'
+    - '.github/workflows/firebaseai.yml'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'
@@ -15,6 +16,7 @@ concurrency:
 
 env:
   SAMPLE: FirebaseAI
+  FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
 
 jobs:
   spm:


### PR DESCRIPTION
Fix for https://github.com/firebase/quickstart-ios/actions/runs/14877284690

firebase-ios-sdk `main`'s Package.swift is pointing to an unreleased FirebaseAnalytics