### PR TITLE
[Firebase AI] Move `GOOGLEAPPMEASUREMENT` flag into `test.sh`

### DIFF
--- a/.github/workflows/firebaseai.yml
+++ b/.github/workflows/firebaseai.yml
@@ -16,7 +16,6 @@ concurrency:
 
 env:
   SAMPLE: FirebaseAI
-  FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
 
 jobs:
   spm:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -131,6 +131,11 @@ function xcb() {
     xcodebuild "$@" | xcpretty
 }
 
+# Point SPM CI to the tip of `main` of
+# https://github.com/google/GoogleAppMeasurement so that the release process
+# can defer publishing the `GoogleAppMeasurement` tag until after testing.
+export FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT=1
+
 # Run xcodebuild
 sudo xcode-select -s "/Applications/Xcode_${xcode_version}.app/Contents/Developer"
 xcb "${flags[@]}"


### PR DESCRIPTION
Moved the `FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT` flag from the `firebaseai` workflow to `test.sh` to handle the SPM builds when `GoogleAppMeasurement` has not yet been released. This is to prepare for future SPM-based quickstarts. See #1701 for the original fix.