### PR TITLE
[Firebase AI] Switch to SemVer tagged `firebase-ios-sdk`

### DIFF
--- a/.github/workflows/firebaseai.yml
+++ b/.github/workflows/firebaseai.yml
@@ -16,7 +16,6 @@ concurrency:
 
 env:
   SAMPLE: FirebaseAI
-  FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
 
 jobs:
   spm:

--- a/firebaseai/FirebaseAIExample.xcodeproj/project.pbxproj
+++ b/firebaseai/FirebaseAIExample.xcodeproj/project.pbxproj
@@ -614,8 +614,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 11.13.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/firebaseai/README.md
+++ b/firebaseai/README.md
@@ -27,7 +27,7 @@ sample app to your Firebase project (or create a new project):
    [Set up a Firebase project and connect your app to Firebase](https://firebase.google.com/docs/vertex-ai/get-started?platform=ios#set-up-firebase).
 2. Add an iOS+ app to your project. Make sure the `Bundle Identifier` you set
    matches the one in the sample.
-     - The default bundle ID is `com.google.firebase.VertexAISample`
+     - The default bundle ID is `com.google.firebase.quickstart.FirebaseAIExample`
 3. Download the `GoogleService-Info.plist` for the app when prompted and save
    it to the `firebaseai` directory.
 


### PR DESCRIPTION
Updated the Firebase AI quickstart to use the tagged release of `firebase-ios-sdk` for the SPM dependency (up to next major version) instead of depending on `main`.