### PR TITLE
[Infra] Remove outdated availability and Swift version guards

### DIFF
--- a/abtesting/Shared/AppConfig.swift
+++ b/abtesting/Shared/AppConfig.swift
@@ -56,7 +56,6 @@ class AppConfig: ObservableObject {
   }
 
   #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
     func updateFromRemoteConfigAsync() async {
       let remoteConfig = RemoteConfig.remoteConfig()
       let oldValue = remoteConfig["color_scheme"].stringValue ?? "nil"

--- a/abtesting/Shared/ContentView.swift
+++ b/abtesting/Shared/ContentView.swift
@@ -40,18 +40,11 @@ struct FirebaseList: View {
   var body: some View {
     VStack {
       #if compiler(>=5.5) && canImport(_Concurrency)
-        if #available(iOS 15, tvOS 15, macOS 12, watchOS 8, *) {
-          BasicList(data: data)
-            .preferredColorScheme(appConfig.colorScheme)
-            .foregroundColor(appConfig.colorScheme == .dark ? .orange : .primary)
-            .task { await appConfig.updateFromRemoteConfigAsync() }
-            .refreshable { await appConfig.updateFromRemoteConfigAsync() }
-        } else {
-          BasicList(data: data)
-            .preferredColorScheme(appConfig.colorScheme)
-            .foregroundColor(appConfig.colorScheme == .dark ? .orange : .primary)
-            .onAppear { appConfig.updateFromRemoteConfig() }
-        }
+        BasicList(data: data)
+          .preferredColorScheme(appConfig.colorScheme)
+          .foregroundColor(appConfig.colorScheme == .dark ? .orange : .primary)
+          .task { await appConfig.updateFromRemoteConfigAsync() }
+          .refreshable { await appConfig.updateFromRemoteConfigAsync() }
       #else
         BasicList(data: data)
           .preferredColorScheme(appConfig.colorScheme)

--- a/abtesting/Shared/UITests.swift
+++ b/abtesting/Shared/UITests.swift
@@ -102,11 +102,9 @@ class UITests: XCTestCase {
   }
 
   func testLaunchPerformance() throws {
-    if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // This measures how long it takes to launch your application.
-      measure(metrics: [XCTApplicationLaunchMetric()]) {
-        XCUIApplication().launch()
-      }
+    // This measures how long it takes to launch your application.
+    measure(metrics: [XCTApplicationLaunchMetric()]) {
+      XCUIApplication().launch()
     }
   }
 }

--- a/analytics/AnalyticsExample/AppDelegate.swift
+++ b/analytics/AnalyticsExample/AppDelegate.swift
@@ -30,13 +30,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                    didFinishLaunchingWithOptions launchOptions: [UIApplication
                      .LaunchOptionsKey: Any]?) -> Bool {
     FirebaseApp.configure()
-    if #available(iOS 14, *) {
-      SKPaymentQueue.default().add(FirebaseApp.app()!)
-      print("\(SKPaymentQueue.default().transactionObservers as [AnyObject])")
+    SKPaymentQueue.default().add(FirebaseApp.app()!)
+    print("\(SKPaymentQueue.default().transactionObservers as [AnyObject])")
 
-      (SKPaymentQueue.default().transactionObservers as [AnyObject]).forEach {
-        print($0)
-      }
+    (SKPaymentQueue.default().transactionObservers as [AnyObject]).forEach {
+      print($0)
     }
     print("done")
     return true

--- a/appdistribution/AppDistributionUITests/AppDistributionExampleUITests.swift
+++ b/appdistribution/AppDistributionUITests/AppDistributionExampleUITests.swift
@@ -36,11 +36,9 @@ class AppDistributionExampleUITests: XCTestCase {
   }
 
   func testLaunchPerformance() throws {
-    if #available(macOS 10.15, iOS 13.0, tvOS 13.0, *) {
-      // This measures how long it takes to launch your application.
-      measure(metrics: [XCTOSSignpostMetric.applicationLaunch]) {
-        XCUIApplication().launch()
-      }
+    // This measures how long it takes to launch your application.
+    measure(metrics: [XCTOSSignpostMetric.applicationLaunch]) {
+      XCUIApplication().launch()
     }
   }
 }

--- a/authentication/LegacyAuthQuickstart/AuthenticationExampleSwift/AppDelegate.swift
+++ b/authentication/LegacyAuthQuickstart/AuthenticationExampleSwift/AppDelegate.swift
@@ -48,7 +48,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   }
 
   // [START new_delegate]
-  @available(iOS 9.0, *)
   func application(_ application: UIApplication, open url: URL,
                    options: [UIApplication.OpenURLOptionsKey: Any])
     -> Bool {

--- a/authentication/LegacyAuthQuickstart/AuthenticationExampleSwift/MainViewController.swift
+++ b/authentication/LegacyAuthQuickstart/AuthenticationExampleSwift/MainViewController.swift
@@ -160,12 +160,8 @@ class MainViewController: UITableViewController {
           }
         }
       case .authApple:
-        if #available(iOS 13, *) {
-          action = UIAlertAction(title: "Apple", style: .default) { UIAlertAction in
-            self.startSignInWithAppleFlow()
-          }
-        } else {
-          continue
+        action = UIAlertAction(title: "Apple", style: .default) { UIAlertAction in
+          self.startSignInWithAppleFlow()
         }
       case .authFacebook:
         action = UIAlertAction(title: "Facebook", style: .default) { UIAlertAction in
@@ -1026,7 +1022,6 @@ class MainViewController: UITableViewController {
   // Unhashed nonce.
   fileprivate var currentNonce: String?
 
-  @available(iOS 13, *)
   func startSignInWithAppleFlow() {
     let nonce = randomNonceString()
     currentNonce = nonce
@@ -1066,7 +1061,6 @@ class MainViewController: UITableViewController {
   // [END random_nonce]
 
   // [START sha_256]
-  @available(iOS 13, *)
   private func sha256(_ input: String) -> String {
     let inputData = Data(input.utf8)
     let hashedData = SHA256.hash(data: inputData)
@@ -1080,7 +1074,6 @@ class MainViewController: UITableViewController {
   // [END sha_256]
 }
 
-@available(iOS 13.0, *)
 extension MainViewController: ASAuthorizationControllerDelegate {
   func authorizationController(controller: ASAuthorizationController,
                                didCompleteWithAuthorization authorization: ASAuthorization) {
@@ -1113,7 +1106,6 @@ extension MainViewController: ASAuthorizationControllerDelegate {
   }
 }
 
-@available(iOS 13.0, *)
 extension MainViewController: ASAuthorizationControllerPresentationContextProviding {
   func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
     return view.window!

--- a/crashlytics/Shared/ContentView.swift
+++ b/crashlytics/Shared/ContentView.swift
@@ -34,7 +34,7 @@ struct ContentView: View {
   private var crashlyticsReference = Crashlytics.crashlytics()
 
   #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *) func checkForUnsentReportsAsync() async {
+    func checkForUnsentReportsAsync() async {
       let reportFound = await crashlyticsReference.checkForUnsentReports()
       if reportFound {
         crashlyticsReference.sendUnsentReports()
@@ -51,24 +51,17 @@ struct ContentView: View {
   }
 
   var body: some View {
-    if #available(iOS 15, tvOS 15, macOS 12, watchOS 8, *) {
-      #if compiler(>=5.5) && canImport(_Concurrency)
-        CrashButtonView()
-          .task {
-            await self.checkForUnsentReportsAsync()
-          }
-      #else
-        CrashButtonView()
-          .onAppear {
-            self.checkForUnsentReports()
-          }
-      #endif
-    } else {
+    #if compiler(>=5.5) && canImport(_Concurrency)
+      CrashButtonView()
+        .task {
+          await self.checkForUnsentReportsAsync()
+        }
+    #else
       CrashButtonView()
         .onAppear {
           self.checkForUnsentReports()
         }
-    }
+    #endif
   }
 }
 

--- a/crashlytics/Shared/UITests.swift
+++ b/crashlytics/Shared/UITests.swift
@@ -36,11 +36,9 @@ class UITests: XCTestCase {
   }
 
   func testLaunchPerformance() throws {
-    if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // This measures how long it takes to launch your application.
-      measure(metrics: [XCTApplicationLaunchMetric()]) {
-        XCUIApplication().launch()
-      }
+    // This measures how long it takes to launch your application.
+    measure(metrics: [XCTApplicationLaunchMetric()]) {
+      XCUIApplication().launch()
     }
   }
 }

--- a/database/DatabaseExampleSwiftUI/DatabaseExample/Shared/Views/PostCell.swift
+++ b/database/DatabaseExampleSwiftUI/DatabaseExample/Shared/Views/PostCell.swift
@@ -31,17 +31,13 @@ struct PostCell: View {
             #if os(iOS) || os(macOS)
               starButton
                 .onTapGesture {
-                  if #available(iOS 15, macOS 12, *) {
-                    #if compiler(>=5.5) && canImport(_Concurrency)
-                      Task { await
-                        post.didTapStarButtonAsync()
-                      }
-                    #else
-                      post.didTapStarButton()
-                    #endif
-                  } else {
+                  #if compiler(>=5.5) && canImport(_Concurrency)
+                    Task { await
+                      post.didTapStarButtonAsync()
+                    }
+                  #else
                     post.didTapStarButton()
-                  }
+                  #endif
                 }
             #elseif os(tvOS)
               starButton

--- a/firestore/FirestoreExample/UINavigationBar+Extension.swift
+++ b/firestore/FirestoreExample/UINavigationBar+Extension.swift
@@ -20,7 +20,6 @@ extension UINavigationBar {
   static let firebaseTitleTextAttributes =
     [NSAttributedString.Key.foregroundColor: UIColor.white]
 
-  @available(iOS 13.0, *)
   var firebaseNavigationBarAppearance: UINavigationBarAppearance {
     let navBarAppearance = UINavigationBarAppearance()
     navBarAppearance.configureWithOpaqueBackground()
@@ -29,14 +28,11 @@ extension UINavigationBar {
     return navBarAppearance
   }
 
-  @available(iOS 13.0, *)
   func applyAppearance(_ appearance: UINavigationBarAppearance) {
     standardAppearance = appearance
     compactAppearance = appearance
     scrollEdgeAppearance = appearance
-    if #available(iOS 15.0, *) {
-      compactScrollEdgeAppearance = appearance
-    }
+    compactScrollEdgeAppearance = appearance
   }
 
   func applyFirebaseAppearance() {
@@ -44,8 +40,6 @@ extension UINavigationBar {
     isTranslucent = false
     titleTextAttributes = UINavigationBar.firebaseTitleTextAttributes
 
-    if #available(iOS 13.0, *) {
-      applyAppearance(firebaseNavigationBarAppearance)
-    }
+    applyAppearance(firebaseNavigationBarAppearance)
   }
 }

--- a/functions/LegacyFunctionsQuickstart/FunctionsExampleSwift/AppDelegate.swift
+++ b/functions/LegacyFunctionsQuickstart/FunctionsExampleSwift/AppDelegate.swift
@@ -41,7 +41,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     return true
   }
 
-  @available(iOS 9.0, *)
   func application(_ app: UIApplication, open url: URL,
                    options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
     guard let sourceApplication =
@@ -51,7 +50,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     return handleOpenUrl(url, sourceApplication: sourceApplication)
   }
 
-  @available(iOS 8.0, *)
   func application(_ application: UIApplication, open url: URL, sourceApplication: String?,
                    annotation: Any) -> Bool {
     return handleOpenUrl(url, sourceApplication: sourceApplication)

--- a/performance/SwiftUIPerformanceQuickstart/PerformanceExample/Shared/Views/ClassifyView.swift
+++ b/performance/SwiftUIPerformanceQuickstart/PerformanceExample/Shared/Views/ClassifyView.swift
@@ -37,15 +37,7 @@ struct ClassifyView: View {
         } else {
           Button("Classify Image") {
             if !process.isRunning {
-              if #available(iOS 15, tvOS 15, *) {
-                #if swift(>=5.5)
-                  Task { await process.classifyImageAsync() }
-                #else
-                  process.classifyImage()
-                #endif
-              } else {
-                process.classifyImage()
-              }
+              Task { await process.classifyImageAsync() }
             }
           }
           .disabled(process.isRunning)

--- a/performance/SwiftUIPerformanceQuickstart/PerformanceExample/Shared/Views/DownloadView.swift
+++ b/performance/SwiftUIPerformanceQuickstart/PerformanceExample/Shared/Views/DownloadView.swift
@@ -32,15 +32,7 @@ struct DownloadView: View {
           .padding(.bottom)
         Button("Download Image") {
           if !process.isRunning {
-            if #available(iOS 15, tvOS 15, *) {
-              #if swift(>=5.5)
-                Task { await process.downloadImageAsync() }
-              #else
-                process.downloadImage()
-              #endif
-            } else {
-              process.downloadImage()
-            }
+            Task { await process.downloadImageAsync() }
           }
         }
         .disabled(process.isRunning)

--- a/performance/SwiftUIPerformanceQuickstart/PerformanceExample/Shared/Views/SaliencyMapView.swift
+++ b/performance/SwiftUIPerformanceQuickstart/PerformanceExample/Shared/Views/SaliencyMapView.swift
@@ -30,15 +30,7 @@ struct SaliencyMapView: View {
           Image(uiImage: image).padding(.bottom)
           Button("Generate Saliency Map") {
             if !process.isRunning {
-              if #available(iOS 15, tvOS 15, *) {
-                #if swift(>=5.5)
-                  Task { await process.generateSaliencyMapAsync() }
-                #else
-                  process.generateSaliencyMap()
-                #endif
-              } else {
-                process.generateSaliencyMap()
-              }
+              Task { await process.generateSaliencyMapAsync() }
             }
           }
           .disabled(process.isRunning)

--- a/performance/SwiftUIPerformanceQuickstart/PerformanceExample/Shared/Views/UploadView.swift
+++ b/performance/SwiftUIPerformanceQuickstart/PerformanceExample/Shared/Views/UploadView.swift
@@ -29,15 +29,7 @@ struct UploadView: View {
         } else {
           Button("Upload Saliency Map") {
             if !process.isRunning {
-              if #available(iOS 15, tvOS 15, *) {
-                #if swift(>=5.5)
-                  Task { await process.uploadSaliencyMapAsync() }
-                #else
-                  process.uploadSaliencyMap()
-                #endif
-              } else {
-                process.uploadSaliencyMap()
-              }
+              Task { await process.uploadSaliencyMapAsync() }
             }
           }
           .disabled(process.isRunning)


### PR DESCRIPTION
Analyzed project deployment targets and removed unnecessary @available, #available, and #if swift guards throughout the codebase.

- iOS deployment target standardized at 15.0.
- macOS deployment target baseline at 11.0.
- tvOS deployment target baseline at 15.0.
- watchOS deployment target baseline at 7.0.

Removed #if swift(>=X.X) blocks by migrating the code for the newer Swift version into the enclosing scope and deleting the #else blocks.