### PR TITLE
[firebaseai] Rename FirebaseAIExample to FirebaseAISample and update README

### DIFF
--- a/firebaseai/FirebaseAISample.xcodeproj/project.pbxproj
+++ b/firebaseai/FirebaseAISample.xcodeproj/project.pbxproj
@@ -327,7 +327,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 8848C82A2B0D04BC007B434F /* Build configuration list for PBXProject "FirebaseAIExample" */;
+			buildConfigurationList = 8848C82A2B0D04BC007B434F /* Build configuration list for PBXProject "FirebaseAISample" */;
 			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -532,7 +532,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.quickstart.FirebaseAIExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.quickstart.FirebaseAISample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -562,7 +562,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.quickstart.FirebaseAIExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.quickstart.FirebaseAISample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -573,7 +573,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		8848C82A2B0D04BC007B434F /* Build configuration list for PBXProject "FirebaseAIExample" */ = {
+		8848C82A2B0D04BC007B434F /* Build configuration list for PBXProject "FirebaseAISample" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				8848C83B2B0D04BD007B434F /* Debug */,

--- a/firebaseai/FirebaseAISample.xcodeproj/xcshareddata/xcschemes/FirebaseAIExample (iOS).xcscheme
+++ b/firebaseai/FirebaseAISample.xcodeproj/xcshareddata/xcschemes/FirebaseAIExample (iOS).xcscheme
@@ -18,7 +18,7 @@
                BlueprintIdentifier = "8848C82E2B0D04BC007B434F"
                BuildableName = "FirebaseAISample.app"
                BlueprintName = "FirebaseAISample"
-               ReferencedContainer = "container:FirebaseAIExample.xcodeproj">
+               ReferencedContainer = "container:FirebaseAISample.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -47,7 +47,7 @@
             BlueprintIdentifier = "8848C82E2B0D04BC007B434F"
             BuildableName = "FirebaseAISample.app"
             BlueprintName = "FirebaseAISample"
-            ReferencedContainer = "container:FirebaseAIExample.xcodeproj">
+            ReferencedContainer = "container:FirebaseAISample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
@@ -70,7 +70,7 @@
             BlueprintIdentifier = "8848C82E2B0D04BC007B434F"
             BuildableName = "FirebaseAISample.app"
             BlueprintName = "FirebaseAISample"
-            ReferencedContainer = "container:FirebaseAIExample.xcodeproj">
+            ReferencedContainer = "container:FirebaseAISample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/firebaseai/README.md
+++ b/firebaseai/README.md
@@ -27,9 +27,10 @@ sample app to your Firebase project (or create a new project):
    [Set up a Firebase project and connect your app to Firebase](https://firebase.google.com/docs/vertex-ai/get-started?platform=ios#set-up-firebase).
 2. Add an iOS+ app to your project. Make sure the `Bundle Identifier` you set
    matches the one in the sample.
-     - The default bundle ID is `com.google.firebase.quickstart.FirebaseAIExample`
+     - The default bundle ID is `com.google.firebase.quickstart.FirebaseAISample`
 3. Download the `GoogleService-Info.plist` for the app when prompted and save
    it to the `firebaseai` directory.
+4. In the Firebase Console, click `AI` and select `AI Logic` to enable Gemini Developer API and Vertex AI Gemini API
 
 You should now be able to build and run the sample!
 

--- a/firebaseai/README.md
+++ b/firebaseai/README.md
@@ -30,7 +30,7 @@ sample app to your Firebase project (or create a new project):
      - The default bundle ID is `com.google.firebase.quickstart.FirebaseAISample`
 3. Download the `GoogleService-Info.plist` for the app when prompted and save
    it to the `firebaseai` directory.
-4. In the Firebase Console, click `AI` and select `AI Logic` to enable Gemini Developer API and Vertex AI Gemini API
+4. In the Firebase Console, click **AI** and select **AI Logic** to enable the Gemini Developer API and Vertex AI Gemini API.
 
 You should now be able to build and run the sample!
 


### PR DESCRIPTION
1. Renamed all occurrences from `FirebaseAIExample` to `FirebaseAISample` to fix a naming inconsistency. The `FirebaseAIExample` appears to be a typo, shoule be `FirebaseAISample`.
2. Added instructions for enabling Gemini APIs in the Firebase Console.