### PR TITLE
[Infra] Upgrade to FirebaseUI v15

### DIFF
--- a/database/Podfile
+++ b/database/Podfile
@@ -6,7 +6,7 @@ platform :ios, '15.0'
 def firebase_pods
   pod 'FirebaseAuth'
   pod 'FirebaseDatabase'
-  pod 'FirebaseUI/Database', '~> 14.0'
+  pod 'FirebaseUI/Database', '~> 15.0'
 end
 
 target 'DatabaseExample' do

--- a/database/Podfile.lock
+++ b/database/Podfile.lock
@@ -24,11 +24,11 @@ PODS:
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - leveldb-library (~> 1.22)
-  - FirebaseDatabaseUI (14.2.0):
-    - FirebaseDatabase (< 12.0, >= 8.0)
+  - FirebaseDatabaseUI (15.1.0):
+    - FirebaseDatabase (< 13.0, >= 8.0)
   - FirebaseSharedSwift (11.15.0)
-  - FirebaseUI/Database (14.2.0):
-    - FirebaseDatabaseUI (~> 14.2)
+  - FirebaseUI/Database (15.1.0):
+    - FirebaseDatabaseUI (~> 15.0)
   - GoogleUtilities/AppDelegateSwizzler (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
@@ -60,7 +60,7 @@ PODS:
 DEPENDENCIES:
   - FirebaseAuth
   - FirebaseDatabase
-  - FirebaseUI/Database (~> 14.0)
+  - FirebaseUI/Database (~> 15.0)
 
 SPEC REPOS:
   trunk:
@@ -87,14 +87,14 @@ SPEC CHECKSUMS:
   FirebaseCoreExtension: edbd30474b5ccf04e5f001470bdf6ea616af2435
   FirebaseCoreInternal: 9afa45b1159304c963da48addb78275ef701c6b4
   FirebaseDatabase: 954eb5613d01573ea50ef839e380edcb68db3707
-  FirebaseDatabaseUI: fa413a4300fa3cba5320958f41ad69d0439b8950
+  FirebaseDatabaseUI: 5280abb5536ee0947e23ab8aaf009342b78a5eb2
   FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
-  FirebaseUI: 3909853fc34f316c822e195376f144b1b0c6ca15
+  FirebaseUI: 1dfcf45d4bb4073380091394c9c555d697ecca11
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMSessionFetcher: fc75fc972958dceedee61cb662ae1da7a83a91cf
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
 
-PODFILE CHECKSUM: d3d479e5d977b9e39fa7d8c214b84e9408ada08b
+PODFILE CHECKSUM: 09457a8084148e1e0568ba26bcfdfbad2285c80d
 
 COCOAPODS: 1.16.2

--- a/firestore/Podfile
+++ b/firestore/Podfile
@@ -4,8 +4,8 @@ target 'FirestoreExample' do
   use_frameworks!
 
   pod 'FirebaseAuth'
-  pod 'FirebaseUI/Auth', '~> 14.0'
-  pod 'FirebaseUI/Email', '~> 14.0'
+  pod 'FirebaseUI/Auth', '~> 15.0'
+  pod 'FirebaseUI/Email', '~> 15.0'
   pod 'FirebaseFirestore'
   pod 'SDWebImage'
 

--- a/firestore/Podfile.lock
+++ b/firestore/Podfile.lock
@@ -1205,8 +1205,8 @@ PODS:
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
     - RecaptchaInterop (~> 101.0)
   - FirebaseAuthInterop (11.15.0)
-  - FirebaseAuthUI (14.2.6):
-    - FirebaseAuth (< 12.0, >= 11.0)
+  - FirebaseAuthUI (15.1.0):
+    - FirebaseAuth (< 13.0, >= 11.0)
     - FirebaseCore
   - FirebaseCore (11.15.0):
     - FirebaseCoreInternal (~> 11.15.0)
@@ -1216,9 +1216,9 @@ PODS:
     - FirebaseCore (~> 11.15.0)
   - FirebaseCoreInternal (11.15.0):
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
-  - FirebaseEmailAuthUI (14.2.3):
+  - FirebaseEmailAuthUI (15.1.0):
     - FirebaseAuth
-    - FirebaseAuthUI (>= 14.2)
+    - FirebaseAuthUI (~> 15.0)
     - FirebaseCore
     - GoogleUtilities/UserDefaults
   - FirebaseFirestore (11.15.0):
@@ -1242,10 +1242,10 @@ PODS:
     - leveldb-library (~> 1.22)
     - nanopb (~> 3.30910.0)
   - FirebaseSharedSwift (11.15.0)
-  - FirebaseUI/Auth (14.2.0):
-    - FirebaseAuthUI (~> 14.2)
-  - FirebaseUI/Email (14.2.0):
-    - FirebaseEmailAuthUI (~> 14.2)
+  - FirebaseUI/Auth (15.1.0):
+    - FirebaseAuthUI (~> 15.0)
+  - FirebaseUI/Email (15.1.0):
+    - FirebaseEmailAuthUI (~> 15.0)
   - GoogleUtilities/AppDelegateSwizzler (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
@@ -1379,8 +1379,8 @@ PODS:
 DEPENDENCIES:
   - FirebaseAuth
   - FirebaseFirestore
-  - FirebaseUI/Auth (~> 14.0)
-  - FirebaseUI/Email (~> 14.0)
+  - FirebaseUI/Auth (~> 15.0)
+  - FirebaseUI/Email (~> 15.0)
   - SDWebImage
   - SDWebImageSwiftUI
 
@@ -1416,15 +1416,15 @@ SPEC CHECKSUMS:
   FirebaseAppCheckInterop: 06fe5a3799278ae4667e6c432edd86b1030fa3df
   FirebaseAuth: a6575e5fbf46b046c58dc211a28a5fbdd8d4c83b
   FirebaseAuthInterop: 7087d7a4ee4bc4de019b2d0c240974ed5d89e2fd
-  FirebaseAuthUI: 8e5c09b20bf11478b9fa42c7ed6575fa95807c86
+  FirebaseAuthUI: c574e8904bd14503ff47e55ba2fc9ec64aacaed6
   FirebaseCore: efb3893e5b94f32b86e331e3bd6dadf18b66568e
   FirebaseCoreExtension: edbd30474b5ccf04e5f001470bdf6ea616af2435
   FirebaseCoreInternal: 9afa45b1159304c963da48addb78275ef701c6b4
-  FirebaseEmailAuthUI: c448736db9fcd5895d29229a9e0aec016ece0389
+  FirebaseEmailAuthUI: b6c80ac6ae42bacf2fece92762fa79bc4ee736ed
   FirebaseFirestore: 1e5fafdac2b2ef1ffc24034460b7b4821a15be96
   FirebaseFirestoreInternal: df9ab608a59a4e8eefd0796ed7652f3c1a88473a
   FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
-  FirebaseUI: 3909853fc34f316c822e195376f144b1b0c6ca15
+  FirebaseUI: 1dfcf45d4bb4073380091394c9c555d697ecca11
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   "gRPC-C++": cc207623316fb041a7a3e774c252cf68a058b9e8
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
@@ -1435,6 +1435,6 @@ SPEC CHECKSUMS:
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SDWebImageSwiftUI: a6d7129fb68fc18c8b930b869ddcfce314e49ded
 
-PODFILE CHECKSUM: 5309ab64953f3e44ffcec5abcfcc35f11873d013
+PODFILE CHECKSUM: 2585dac1c3f679eecfb4775b842304e0377270b5
 
 COCOAPODS: 1.16.2

--- a/functions/LegacyFunctionsQuickstart/Podfile
+++ b/functions/LegacyFunctionsQuickstart/Podfile
@@ -5,8 +5,8 @@ platform :ios, '15.0'
 
 pod 'FirebaseAnalytics'
 pod 'FirebaseAuth'
-pod 'FirebaseUI/Auth', '~> 14.0'
-pod 'FirebaseUI/Google', '~> 14.0'
+pod 'FirebaseUI/Auth', '~> 15.0'
+pod 'FirebaseUI/Google', '~> 15.0'
 # [START functions_pod]
 pod 'FirebaseFunctions'
 # [END functions_pod]

--- a/functions/LegacyFunctionsQuickstart/Podfile.lock
+++ b/functions/LegacyFunctionsQuickstart/Podfile.lock
@@ -5,6 +5,10 @@ PODS:
   - AppAuth/Core (1.7.6)
   - AppAuth/ExternalUserAgent (1.7.6):
     - AppAuth/Core
+  - AppCheckCore (11.2.0):
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - PromisesObjC (~> 2.4)
   - FirebaseAnalytics (11.15.0):
     - FirebaseAnalytics/Default (= 11.15.0)
     - FirebaseCore (~> 11.15.0)
@@ -34,8 +38,8 @@ PODS:
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
     - RecaptchaInterop (~> 101.0)
   - FirebaseAuthInterop (11.15.0)
-  - FirebaseAuthUI (14.2.6):
-    - FirebaseAuth (< 12.0, >= 11.0)
+  - FirebaseAuthUI (15.1.0):
+    - FirebaseAuth (< 13.0, >= 11.0)
     - FirebaseCore
   - FirebaseCore (11.15.0):
     - FirebaseCoreInternal (~> 11.15.0)
@@ -53,11 +57,11 @@ PODS:
     - FirebaseMessagingInterop (~> 11.0)
     - FirebaseSharedSwift (~> 11.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
-  - FirebaseGoogleAuthUI (14.2.2):
+  - FirebaseGoogleAuthUI (15.1.0):
     - FirebaseAuth
-    - FirebaseAuthUI (>= 14.2)
+    - FirebaseAuthUI (~> 15.0)
     - FirebaseCore
-    - GoogleSignIn (~> 7.0)
+    - GoogleSignIn (~> 8.0)
   - FirebaseInstallations (11.15.0):
     - FirebaseCore (~> 11.15.0)
     - GoogleUtilities/Environment (~> 8.1)
@@ -65,10 +69,10 @@ PODS:
     - PromisesObjC (~> 2.4)
   - FirebaseMessagingInterop (11.15.0)
   - FirebaseSharedSwift (11.15.0)
-  - FirebaseUI/Auth (14.2.0):
-    - FirebaseAuthUI (~> 14.2)
-  - FirebaseUI/Google (14.2.0):
-    - FirebaseGoogleAuthUI (~> 14.2)
+  - FirebaseUI/Auth (15.1.0):
+    - FirebaseAuthUI (~> 15.0)
+  - FirebaseUI/Google (15.1.0):
+    - FirebaseGoogleAuthUI (~> 15.0)
   - GoogleAdsOnDeviceConversion (2.1.0):
     - GoogleUtilities/Logger (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
@@ -95,8 +99,9 @@ PODS:
     - GoogleUtilities/Network (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
     - nanopb (~> 3.30910.0)
-  - GoogleSignIn (7.1.0):
+  - GoogleSignIn (8.0.0):
     - AppAuth (< 2.0, >= 1.7.3)
+    - AppCheckCore (~> 11.0)
     - GTMAppAuth (< 5.0, >= 4.1.1)
     - GTMSessionFetcher/Core (~> 3.3)
   - GoogleUtilities/AppDelegateSwizzler (8.1.0):
@@ -239,8 +244,8 @@ DEPENDENCIES:
   - FirebaseAnalytics
   - FirebaseAuth
   - FirebaseFunctions
-  - FirebaseUI/Auth (~> 14.0)
-  - FirebaseUI/Google (~> 14.0)
+  - FirebaseUI/Auth (~> 15.0)
+  - FirebaseUI/Google (~> 15.0)
   - MaterialComponents/Buttons
   - MaterialComponents/Collections
   - MaterialComponents/TextFields
@@ -248,6 +253,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - AppAuth
+    - AppCheckCore
     - FirebaseAnalytics
     - FirebaseAppCheckInterop
     - FirebaseAuth
@@ -277,23 +283,24 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
+  AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   FirebaseAnalytics: 6433dfd311ba78084fc93bdfc145e8cb75740eae
   FirebaseAppCheckInterop: 06fe5a3799278ae4667e6c432edd86b1030fa3df
   FirebaseAuth: a6575e5fbf46b046c58dc211a28a5fbdd8d4c83b
   FirebaseAuthInterop: 7087d7a4ee4bc4de019b2d0c240974ed5d89e2fd
-  FirebaseAuthUI: 8e5c09b20bf11478b9fa42c7ed6575fa95807c86
+  FirebaseAuthUI: c574e8904bd14503ff47e55ba2fc9ec64aacaed6
   FirebaseCore: efb3893e5b94f32b86e331e3bd6dadf18b66568e
   FirebaseCoreExtension: edbd30474b5ccf04e5f001470bdf6ea616af2435
   FirebaseCoreInternal: 9afa45b1159304c963da48addb78275ef701c6b4
   FirebaseFunctions: 86062a3ba8c7420e6b6fe22c8a1e1150332286de
-  FirebaseGoogleAuthUI: bbfd673275e4a4a4a3d0e451884087452d088453
+  FirebaseGoogleAuthUI: 740a15519a36b4d15802c4ef1db4aaeb7f7bad0b
   FirebaseInstallations: 317270fec08a5d418fdbc8429282238cab3ac843
   FirebaseMessagingInterop: 63e504b147a7206cfe64cbe2f40c2ddd009945bd
   FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
-  FirebaseUI: 3909853fc34f316c822e195376f144b1b0c6ca15
+  FirebaseUI: 1dfcf45d4bb4073380091394c9c555d697ecca11
   GoogleAdsOnDeviceConversion: 2be6297a4f048459e0ae17fad9bfd2844e10cf64
   GoogleAppMeasurement: 700dce7541804bec33db590a5c496b663fbe2539
-  GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
+  GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
@@ -304,6 +311,6 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
 
-PODFILE CHECKSUM: 0184ee51f477ca21b8573970813f92a89aa3cf4a
+PODFILE CHECKSUM: 56b139ff3f9ff3b9dfe39b30951b6aad99eb689e
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
Unrelated to access tokens, but the only thing keeping firebase-ios-sdk `prerelease` and `release` workflows from passing at this point.