### PR TITLE
[FirebaseAI] Add Message Sender Label in ChatExample

### DIFF
--- a/firebaseai/ChatExample/Views/MessageView.swift
+++ b/firebaseai/ChatExample/Views/MessageView.swift
@@ -82,7 +82,7 @@ struct ResponseTextView: View {
 
 struct MessageView: View {
   var message: ChatMessage
-  
+
   private var participantLabel: String {
     message.participant == .user ? "User" : "Model"
   }
@@ -98,7 +98,7 @@ struct MessageView: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 2)
         .frame(maxWidth: .infinity, alignment: message.participant == .user ? .trailing : .leading)
-      
+
       // Message content
       HStack {
         if message.participant == .user {

--- a/firebaseai/ChatExample/Views/MessageView.swift
+++ b/firebaseai/ChatExample/Views/MessageView.swift
@@ -82,17 +82,25 @@ struct ResponseTextView: View {
 
 struct MessageView: View {
   var message: ChatMessage
+  
+  private var participantLabel: String {
+    message.participant == .user ? "USER" : "MODEL"
+  }
+  
+  private var alignment: HorizontalAlignment {
+    message.participant == .user ? .trailing : .leading
+  }
 
   var body: some View {
-    VStack(alignment: message.participant == .user ? .trailing : .leading, spacing: 4) {
+    VStack(alignment: alignment, spacing: 4) {
       // Sender label
-      Text(message.participant == .user ? "USER" : "MODEL")
+      Text(participantLabel)
         .font(.caption2)
         .fontWeight(.medium)
         .foregroundColor(.secondary)
         .padding(.horizontal, 8)
         .padding(.vertical, 2)
-        .frame(maxWidth: .infinity, alignment: message.participant == .user ? .trailing : .leading)
+        .frame(maxWidth: .infinity, alignment: alignment)
       
       // Message content
       HStack {

--- a/firebaseai/ChatExample/Views/MessageView.swift
+++ b/firebaseai/ChatExample/Views/MessageView.swift
@@ -84,23 +84,20 @@ struct MessageView: View {
   var message: ChatMessage
   
   private var participantLabel: String {
-    message.participant == .user ? "USER" : "MODEL"
-  }
-  
-  private var alignment: HorizontalAlignment {
-    message.participant == .user ? .trailing : .leading
+    message.participant == .user ? "User" : "Model"
   }
 
   var body: some View {
-    VStack(alignment: alignment, spacing: 4) {
+    VStack(alignment: message.participant == .user ? .trailing : .leading, spacing: 4) {
       // Sender label
       Text(participantLabel)
         .font(.caption2)
         .fontWeight(.medium)
         .foregroundColor(.secondary)
+        .textCase(.uppercase)
         .padding(.horizontal, 8)
         .padding(.vertical, 2)
-        .frame(maxWidth: .infinity, alignment: alignment)
+        .frame(maxWidth: .infinity, alignment: message.participant == .user ? .trailing : .leading)
       
       // Message content
       HStack {

--- a/firebaseai/ChatExample/Views/MessageView.swift
+++ b/firebaseai/ChatExample/Views/MessageView.swift
@@ -84,23 +84,35 @@ struct MessageView: View {
   var message: ChatMessage
 
   var body: some View {
-    HStack {
-      if message.participant == .user {
-        Spacer()
-      }
-      MessageContentView(message: message)
-        .padding(10)
-        .background(message.participant == .system
-          ? Color(UIColor.systemFill)
-          : Color(UIColor.systemBlue))
-        .roundedCorner(10,
-                       corners: [
-                         .topLeft,
-                         .topRight,
-                         message.participant == .system ? .bottomRight : .bottomLeft,
-                       ])
-      if message.participant == .system {
-        Spacer()
+    VStack(alignment: message.participant == .user ? .trailing : .leading, spacing: 4) {
+      // Sender label
+      Text(message.participant == .user ? "USER" : "MODEL")
+        .font(.caption2)
+        .fontWeight(.medium)
+        .foregroundColor(.secondary)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 2)
+        .frame(maxWidth: .infinity, alignment: message.participant == .user ? .trailing : .leading)
+      
+      // Message content
+      HStack {
+        if message.participant == .user {
+          Spacer()
+        }
+        MessageContentView(message: message)
+          .padding(10)
+          .background(message.participant == .system
+            ? Color(UIColor.systemFill)
+            : Color(UIColor.systemBlue))
+          .roundedCorner(10,
+                         corners: [
+                           .topLeft,
+                           .topRight,
+                           message.participant == .system ? .bottomRight : .bottomLeft,
+                         ])
+        if message.participant == .system {
+          Spacer()
+        }
       }
     }
     .listRowSeparator(.hidden)


### PR DESCRIPTION
Add labels to the chat bubbles in MessageView.swift, aligning the USER label to the right and the MODEL label to the left.

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-27 at 22 57 03" src="https://github.com/user-attachments/assets/db9cd371-7d87-414c-ad06-ced344690e96" />
