### PR TITLE
[FirebaseAI] Change Participant.system case to Participant.model case

### DIFF
--- a/firebaseai/ChatExample/Models/ChatMessage.swift
+++ b/firebaseai/ChatExample/Models/ChatMessage.swift
@@ -16,7 +16,7 @@ import FirebaseAI
 import Foundation
 
 enum Participant {
-  case system
+  case model
   case user
 }
 
@@ -40,7 +40,7 @@ struct ChatMessage: Identifiable, Equatable {
 
 extension ChatMessage {
   static var samples: [ChatMessage] = [
-    .init(message: "Hello. What can I do for you today?", participant: .system),
+    .init(message: "Hello. What can I do for you today?", participant: .model),
     .init(message: "Show me a simple loop in Swift.", participant: .user),
     .init(message: """
     Sure, here is a simple loop in Swift:
@@ -65,7 +65,7 @@ extension ChatMessage {
     ```
 
     This loop calculates the sum of the numbers from 1 to 100. The variable sum is initialized to 0, and then the for loop iterates over the range of numbers from 1 to 100. The variable i is assigned each number in the range, and the value of i is added to the sum variable. After the loop has finished executing, the value of sum is printed to the console.
-    """, participant: .system),
+    """, participant: .model),
   ]
 
   static var sample = samples[0]

--- a/firebaseai/ChatExample/ViewModels/ConversationViewModel.swift
+++ b/firebaseai/ChatExample/ViewModels/ConversationViewModel.swift
@@ -81,7 +81,7 @@ class ConversationViewModel: ObservableObject {
       messages.append(userMessage)
 
       // add a pending message while we're waiting for a response from the backend
-      let systemMessage = ChatMessage.pending(participant: .system)
+      let systemMessage = ChatMessage.pending(participant: .model)
       messages.append(systemMessage)
 
       do {
@@ -121,7 +121,7 @@ class ConversationViewModel: ObservableObject {
       messages.append(userMessage)
 
       // add a pending message while we're waiting for a response from the backend
-      let systemMessage = ChatMessage.pending(participant: .system)
+      let systemMessage = ChatMessage.pending(participant: .model)
       messages.append(systemMessage)
 
       do {

--- a/firebaseai/ChatExample/Views/MessageView.swift
+++ b/firebaseai/ChatExample/Views/MessageView.swift
@@ -62,7 +62,7 @@ struct ResponseTextView: View {
       .markdownTextStyle {
         FontFamilyVariant(.normal)
         FontSize(.em(0.85))
-        ForegroundColor(message.participant == .system ? Color(UIColor.label) : .white)
+        ForegroundColor(message.participant == .model ? Color(UIColor.label) : .white)
       }
       .markdownBlockStyle(\.codeBlock) { configuration in
         configuration.label
@@ -90,16 +90,16 @@ struct MessageView: View {
       }
       MessageContentView(message: message)
         .padding(10)
-        .background(message.participant == .system
+        .background(message.participant == .model
           ? Color(UIColor.systemFill)
           : Color(UIColor.systemBlue))
         .roundedCorner(10,
                        corners: [
                          .topLeft,
                          .topRight,
-                         message.participant == .system ? .bottomRight : .bottomLeft,
+                         message.participant == .model ? .bottomRight : .bottomLeft,
                        ])
-      if message.participant == .system {
+      if message.participant == .model {
         Spacer()
       }
     }
@@ -114,7 +114,7 @@ struct MessageView_Previews: PreviewProvider {
         MessageView(message: ChatMessage.samples[0])
         MessageView(message: ChatMessage.samples[1])
         MessageView(message: ChatMessage.samples[2])
-        MessageView(message: ChatMessage(message: "Hello!", participant: .system, pending: true))
+        MessageView(message: ChatMessage(message: "Hello!", participant: .model, pending: true))
       }
       .listStyle(.plain)
       .navigationTitle("Chat example")

--- a/firebaseai/FunctionCallingExample/ViewModels/FunctionCallingViewModel.swift
+++ b/firebaseai/FunctionCallingExample/ViewModels/FunctionCallingViewModel.swift
@@ -75,7 +75,7 @@ class FunctionCallingViewModel: ObservableObject {
       messages.append(userMessage)
 
       // add a pending message while we're waiting for a response from the backend
-      let systemMessage = ChatMessage.pending(participant: .system)
+      let systemMessage = ChatMessage.pending(participant: .model)
       messages.append(systemMessage)
 
       print(messages)
@@ -224,7 +224,7 @@ private extension FunctionCallPart {
     }
     let messageText = "Function call requested by model:\n```\n\(json)\n```"
 
-    return ChatMessage(message: messageText, participant: .system)
+    return ChatMessage(message: messageText, participant: .model)
   }
 }
 


### PR DESCRIPTION
According to the [Firebase AI Logic document](https://firebase.google.com/docs/ai-logic/chat?api=dev#chat-prompt), the role in `ModelContent` for chat history should be either user or model. Therefore, Participant.system is suggested to be updated to Participant.model to maintain consistency.

<img width="863" height="883" alt="image" src="https://github.com/user-attachments/assets/9eee3639-fc0a-4753-9d74-4176d7ec4a61" />
