### PR TITLE
[CI] Run all `macos-15` jobs with Xcode 16.4

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: macOS-15
     strategy:
       matrix:
-        xcode: ["16.1"]
+        xcode: ["16.4"]
         os: [iOS, tvOS, macOS, watchOS, catalyst]
         include:
           - os: iOS

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -35,7 +35,7 @@ jobs:
         # TODO: Re-enable when ODM2 catalyst support is investigated
         # os: [iOS, catalyst, tvOS, macOS]        
         os: [iOS, tvOS, macOS]
-        xcode: ["16.1"]
+        xcode: ["16.4"]
         include:
           - os: iOS
             device: iPhone 16

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: macOS-15
     strategy:
       matrix:
-        xcode: ["16.1"]
+        xcode: ["16.4"]
         os: [iOS, tvOS, macOS, watchOS]
         include:
           - os: iOS

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: macOS-15
     strategy:
       matrix:
-        xcode: ["16.1"]
+        xcode: ["16.4"]
         os: [iOS, tvOS, macOS]
         include:
           - os: iOS

--- a/.github/workflows/firebaseai.yml
+++ b/.github/workflows/firebaseai.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macOS-15
     strategy:
       matrix:
-        xcode: ["16.3"]
+        xcode: ["16.4"]
         os: [iOS]
         include:
           - os: iOS

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: macOS-15
     strategy:
       matrix:
-        xcode: ["16.1"]
+        xcode: ["16.4"]
         os: [iOS, tvOS, macOS]
         include:
           - os: iOS

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: macOS-15
     strategy:
       matrix:
-        xcode: ["16.1"]
+        xcode: ["16.4"]
         os: [iOS, tvOS]
         include:
           - os: iOS

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: macOS-15
     strategy:
       matrix:
-        xcode: ["16.1"]
+        xcode: ["16.4"]
         os: [iOS, tvOS, macOS]
         include:
           - os: iOS

--- a/scripts/build-for-testing.sh
+++ b/scripts/build-for-testing.sh
@@ -90,7 +90,7 @@ function xcb() {
 }
 
 # Run xcodebuild
-sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 xcb "${flags[@]}"
 echo "$message"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,8 +20,8 @@
 
 set -euo pipefail
 
-if [ -d "/Applications/Xcode_16.2.app" ]; then
-    xcode_version="16.2"
+if [ -d "/Applications/Xcode_16.4.app" ]; then
+    xcode_version="16.4"
     iphone_version="16"
 else
     xcode_version="15.3"


### PR DESCRIPTION
Updated all `macos-15` jobs to use Xcode 16.4 instead of 16.2 since the platforms/simulators are now only included in Xcode 16.3, 16.4 and 26 Beta. The alternative would be to install the platforms with, e.g., `xcodebuild -downloadPlatform iOS` to continue using 16.2 on macOS 15.

> Platform tools (SDK and simulator runtimes) will only be available for the three most recently installed versions of Xcode, including beta and pre-release versions for macOS-15-based and later images.
-- https://github.com/actions/runner-images/issues/12541