### PR TITLE
[CI] Remove Xcode 15 support from `test.sh`

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -28,8 +28,6 @@ if [[ "$xcode_major" -ge 26 ]]; then
   iphone_version="17"
 elif [[ "$xcode_major" -ge 16 ]]; then
   iphone_version="16"
-elif [[ "$xcode_major" -ge 15 ]]; then
-  iphone_version="15"
 else
   echo "Unsupported Xcode version $xcode_version; exiting." 1>&2
   exit 1


### PR DESCRIPTION
Updated `test.sh` to remove the logic for Xcode 15, which is no longer supported.