### PR TITLE
[Firebase AI] Upgrade `swift-markdown-ui` dependency

### DIFF
--- a/firebaseai/FirebaseAIExample.xcodeproj/project.pbxproj
+++ b/firebaseai/FirebaseAIExample.xcodeproj/project.pbxproj
@@ -785,7 +785,7 @@
 			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
 			requirement = {
 				kind = revision;
-				revision = 55441810c0f678c78ed7e2ebd46dde89228e02fc;
+				revision = 5f613358148239d0292c0cef674a3c2314737f9e;
 			};
 		};
 		DEA09AC32B1FCE22001962D9 /* XCRemoteSwiftPackageReference "NetworkImage" */ = {


### PR DESCRIPTION
Upgraded the `swift-markdown-ui` dependency from https://github.com/gonzalezreal/swift-markdown-ui/releases/tag/2.4.0 to https://github.com/gonzalezreal/swift-markdown-ui/releases/tag/2.4.1.