### PR TITLE
[Firebase AI] Add references to zip frameworks in xcodeproj

### DIFF
--- a/firebaseai/ChatExample/Models/ChatMessage.swift
+++ b/firebaseai/ChatExample/Models/ChatMessage.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 import Foundation
 
 enum Participant {

--- a/firebaseai/ChatExample/Screens/ConversationScreen.swift
+++ b/firebaseai/ChatExample/Screens/ConversationScreen.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 import GenerativeAIUIComponents
 import SwiftUI
 

--- a/firebaseai/ChatExample/ViewModels/ConversationViewModel.swift
+++ b/firebaseai/ChatExample/ViewModels/ConversationViewModel.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 import Foundation
 import UIKit
 

--- a/firebaseai/ChatExample/Views/ErrorDetailsView.swift
+++ b/firebaseai/ChatExample/Views/ErrorDetailsView.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 import MarkdownUI
 import SwiftUI
 

--- a/firebaseai/ChatExample/Views/ErrorView.swift
+++ b/firebaseai/ChatExample/Views/ErrorView.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 import SwiftUI
 
 struct ErrorView: View {

--- a/firebaseai/ChatExample/Views/Grounding/GroundedResponseView.swift
+++ b/firebaseai/ChatExample/Views/Grounding/GroundedResponseView.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 import SwiftUI
 
 /// A view that displays a chat message that is grounded in Google Search.

--- a/firebaseai/ChatExample/Views/MessageView.swift
+++ b/firebaseai/ChatExample/Views/MessageView.swift
@@ -14,7 +14,11 @@
 
 import MarkdownUI
 import SwiftUI
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 
 struct RoundedCorner: Shape {
   var radius: CGFloat = .infinity

--- a/firebaseai/FirebaseAIExample.xcodeproj/project.pbxproj
+++ b/firebaseai/FirebaseAIExample.xcodeproj/project.pbxproj
@@ -7,6 +7,20 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		860F09212E8C4179002D85D0 /* FirebaseAILogic.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 860F09142E8C4171002D85D0 /* FirebaseAILogic.xcframework */; };
+		860F09222E8C4179002D85D0 /* FirebaseAILogic.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 860F09142E8C4171002D85D0 /* FirebaseAILogic.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		860F09242E8C417A002D85D0 /* FirebaseAppCheckInterop.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 860F09152E8C4171002D85D0 /* FirebaseAppCheckInterop.xcframework */; };
+		860F09252E8C417A002D85D0 /* FirebaseAppCheckInterop.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 860F09152E8C4171002D85D0 /* FirebaseAppCheckInterop.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		860F09262E8C417B002D85D0 /* FirebaseAuthInterop.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 860F09162E8C4171002D85D0 /* FirebaseAuthInterop.xcframework */; };
+		860F09272E8C417B002D85D0 /* FirebaseAuthInterop.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 860F09162E8C4171002D85D0 /* FirebaseAuthInterop.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		860F09282E8C417C002D85D0 /* FirebaseCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 860F09172E8C4171002D85D0 /* FirebaseCore.xcframework */; };
+		860F09292E8C417C002D85D0 /* FirebaseCore.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 860F09172E8C4171002D85D0 /* FirebaseCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		860F092A2E8C417E002D85D0 /* FirebaseCoreExtension.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 860F09182E8C4171002D85D0 /* FirebaseCoreExtension.xcframework */; };
+		860F092B2E8C417E002D85D0 /* FirebaseCoreExtension.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 860F09182E8C4171002D85D0 /* FirebaseCoreExtension.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		860F092C2E8C417F002D85D0 /* FirebaseCoreInternal.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 860F09192E8C4171002D85D0 /* FirebaseCoreInternal.xcframework */; };
+		860F092D2E8C417F002D85D0 /* FirebaseCoreInternal.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 860F09192E8C4171002D85D0 /* FirebaseCoreInternal.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		860F09302E8C422B002D85D0 /* GoogleUtilities.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 860F092E2E8C4210002D85D0 /* GoogleUtilities.xcframework */; };
+		860F09312E8C422B002D85D0 /* GoogleUtilities.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 860F092E2E8C4210002D85D0 /* GoogleUtilities.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		869200B32B879C4F00482873 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 869200B22B879C4F00482873 /* GoogleService-Info.plist */; };
 		86BB55EA2E8B2D6D0054B8B5 /* FunctionCallingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C1F47E2BC726150026816F /* FunctionCallingScreen.swift */; };
 		86BB55EB2E8B2D6D0054B8B5 /* BouncingDots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E10F5C2B11135000C08E95 /* BouncingDots.swift */; };
@@ -58,7 +72,34 @@
 		DEFECAAA2D7B4CCD00EF9621 /* ImagenScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFECAA62D7B4CCD00EF9621 /* ImagenScreen.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		860F09232E8C4179002D85D0 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				860F092B2E8C417E002D85D0 /* FirebaseCoreExtension.xcframework in Embed Frameworks */,
+				860F09272E8C417B002D85D0 /* FirebaseAuthInterop.xcframework in Embed Frameworks */,
+				860F09312E8C422B002D85D0 /* GoogleUtilities.xcframework in Embed Frameworks */,
+				860F092D2E8C417F002D85D0 /* FirebaseCoreInternal.xcframework in Embed Frameworks */,
+				860F09292E8C417C002D85D0 /* FirebaseCore.xcframework in Embed Frameworks */,
+				860F09222E8C4179002D85D0 /* FirebaseAILogic.xcframework in Embed Frameworks */,
+				860F09252E8C417A002D85D0 /* FirebaseAppCheckInterop.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		860F09142E8C4171002D85D0 /* FirebaseAILogic.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = FirebaseAILogic.xcframework; sourceTree = "<group>"; };
+		860F09152E8C4171002D85D0 /* FirebaseAppCheckInterop.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = FirebaseAppCheckInterop.xcframework; sourceTree = "<group>"; };
+		860F09162E8C4171002D85D0 /* FirebaseAuthInterop.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = FirebaseAuthInterop.xcframework; sourceTree = "<group>"; };
+		860F09172E8C4171002D85D0 /* FirebaseCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = FirebaseCore.xcframework; sourceTree = "<group>"; };
+		860F09182E8C4171002D85D0 /* FirebaseCoreExtension.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = FirebaseCoreExtension.xcframework; sourceTree = "<group>"; };
+		860F09192E8C4171002D85D0 /* FirebaseCoreInternal.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = FirebaseCoreInternal.xcframework; sourceTree = "<group>"; };
+		860F092E2E8C4210002D85D0 /* GoogleUtilities.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GoogleUtilities.xcframework; sourceTree = "<group>"; };
 		869200B22B879C4F00482873 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		86BB56082E8B2D6D0054B8B5 /* FirebaseAIExampleZip.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FirebaseAIExampleZip.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		86C1F47E2BC726150026816F /* FunctionCallingScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionCallingScreen.swift; sourceTree = "<group>"; };
@@ -98,6 +139,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				86BB55FF2E8B2D6D0054B8B5 /* MarkdownUI in Frameworks */,
+				860F09282E8C417C002D85D0 /* FirebaseCore.xcframework in Frameworks */,
+				860F09262E8C417B002D85D0 /* FirebaseAuthInterop.xcframework in Frameworks */,
+				860F09212E8C4179002D85D0 /* FirebaseAILogic.xcframework in Frameworks */,
+				860F092C2E8C417F002D85D0 /* FirebaseCoreInternal.xcframework in Frameworks */,
+				860F09302E8C422B002D85D0 /* GoogleUtilities.xcframework in Frameworks */,
+				860F09242E8C417A002D85D0 /* FirebaseAppCheckInterop.xcframework in Frameworks */,
+				860F092A2E8C417E002D85D0 /* FirebaseCoreExtension.xcframework in Frameworks */,
 				86BB56002E8B2D6D0054B8B5 /* GenerativeAIUIComponents in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -115,6 +163,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		860F091A2E8C4171002D85D0 /* Firebase */ = {
+			isa = PBXGroup;
+			children = (
+				860F09142E8C4171002D85D0 /* FirebaseAILogic.xcframework */,
+				860F09152E8C4171002D85D0 /* FirebaseAppCheckInterop.xcframework */,
+				860F09162E8C4171002D85D0 /* FirebaseAuthInterop.xcframework */,
+				860F09172E8C4171002D85D0 /* FirebaseCore.xcframework */,
+				860F09182E8C4171002D85D0 /* FirebaseCoreExtension.xcframework */,
+				860F09192E8C4171002D85D0 /* FirebaseCoreInternal.xcframework */,
+				860F092E2E8C4210002D85D0 /* GoogleUtilities.xcframework */,
+			);
+			path = Firebase;
+			sourceTree = "<group>";
+		};
 		86C1F47F2BC726150026816F /* Screens */ = {
 			isa = PBXGroup;
 			children = (
@@ -192,6 +254,7 @@
 				86C1F4822BC726150026816F /* FunctionCallingExample */,
 				8848C8302B0D04BC007B434F /* Products */,
 				88209C222B0FBE1700F64795 /* Frameworks */,
+				860F091A2E8C4171002D85D0 /* Firebase */,
 			);
 			sourceTree = "<group>";
 		};
@@ -346,6 +409,7 @@
 				86BB55E92E8B2D6D0054B8B5 /* Sources */,
 				86BB55FD2E8B2D6D0054B8B5 /* Frameworks */,
 				86BB56012E8B2D6D0054B8B5 /* Resources */,
+				860F09232E8C4179002D85D0 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/firebaseai/FirebaseAIExample/ContentView.swift
+++ b/firebaseai/FirebaseAIExample/ContentView.swift
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 import SwiftUI
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 
 enum BackendOption: String, CaseIterable, Identifiable {
   case googleAI = "Gemini Developer API"

--- a/firebaseai/FunctionCallingExample/Screens/FunctionCallingScreen.swift
+++ b/firebaseai/FunctionCallingExample/Screens/FunctionCallingScreen.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 import GenerativeAIUIComponents
 import SwiftUI
 

--- a/firebaseai/FunctionCallingExample/ViewModels/FunctionCallingViewModel.swift
+++ b/firebaseai/FunctionCallingExample/ViewModels/FunctionCallingViewModel.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 import Foundation
 import UIKit
 

--- a/firebaseai/GenerativeAIMultimodalExample/Screens/PhotoReasoningScreen.swift
+++ b/firebaseai/GenerativeAIMultimodalExample/Screens/PhotoReasoningScreen.swift
@@ -16,7 +16,11 @@ import GenerativeAIUIComponents
 import MarkdownUI
 import PhotosUI
 import SwiftUI
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 
 struct PhotoReasoningScreen: View {
   let firebaseService: FirebaseAI

--- a/firebaseai/GenerativeAIMultimodalExample/ViewModels/PhotoReasoningViewModel.swift
+++ b/firebaseai/GenerativeAIMultimodalExample/ViewModels/PhotoReasoningViewModel.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 import Foundation
 import OSLog
 import PhotosUI

--- a/firebaseai/GenerativeAITextExample/Screens/GenerateContentScreen.swift
+++ b/firebaseai/GenerativeAITextExample/Screens/GenerateContentScreen.swift
@@ -14,7 +14,11 @@
 
 import MarkdownUI
 import SwiftUI
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 import GenerativeAIUIComponents
 
 struct GenerateContentScreen: View {

--- a/firebaseai/GenerativeAITextExample/ViewModels/GenerateContentViewModel.swift
+++ b/firebaseai/GenerativeAITextExample/ViewModels/GenerateContentViewModel.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 import Foundation
 import OSLog
 

--- a/firebaseai/ImagenScreen/ImagenScreen.swift
+++ b/firebaseai/ImagenScreen/ImagenScreen.swift
@@ -14,7 +14,11 @@
 
 import SwiftUI
 import GenerativeAIUIComponents
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 
 struct ImagenScreen: View {
   let firebaseService: FirebaseAI

--- a/firebaseai/ImagenScreen/ImagenViewModel.swift
+++ b/firebaseai/ImagenScreen/ImagenViewModel.swift
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseAI
+#if canImport(FirebaseAILogic)
+  import FirebaseAILogic
+#else
+  import FirebaseAI
+#endif
 import Foundation
 import OSLog
 import SwiftUI


### PR DESCRIPTION
- Added references to the zip frameworks in the `FirebaseAIExample` Xcode project in a `Firebase` directory (this aligns with where they are extracted in the zip quickstart tests in `firebase-ios-sdk`.
- Updated imports to use `import FirebaseAILogic` when available. The `#if canImport(FirebaseAILogic)` can be removed after the rename is released.