### PR TITLE
[Firebase AI] Update models to newer versions

### DIFF
--- a/firebaseai/FirebaseAIExample/ChatExample/Screens/ConversationScreen.swift
+++ b/firebaseai/FirebaseAIExample/ChatExample/Screens/ConversationScreen.swift
@@ -30,7 +30,7 @@ struct ConversationScreen: View {
 
   init(firebaseService: FirebaseAI, title: String, searchGroundingEnabled: Bool = false) {
     let model = firebaseService.generativeModel(
-      modelName: "gemini-2.0-flash-001",
+      modelName: "gemini-2.5-flash-lite",
       tools: searchGroundingEnabled ? [.googleSearch()] : []
     )
     self.title = title

--- a/firebaseai/FirebaseAIExample/ChatExample/ViewModels/ConversationViewModel.swift
+++ b/firebaseai/FirebaseAIExample/ChatExample/ViewModels/ConversationViewModel.swift
@@ -44,7 +44,7 @@ class ConversationViewModel: ObservableObject {
       self.model = model
     } else {
       self.model = firebaseService.generativeModel(
-        modelName: "gemini-2.0-flash-001"
+        modelName: "gemini-2.5-flash-lite"
       )
     }
     chat = self.model.startChat()

--- a/firebaseai/FirebaseAIExample/FunctionCallingExample/ViewModels/FunctionCallingViewModel.swift
+++ b/firebaseai/FirebaseAIExample/FunctionCallingExample/ViewModels/FunctionCallingViewModel.swift
@@ -43,7 +43,7 @@ class FunctionCallingViewModel: ObservableObject {
 
   init(firebaseService: FirebaseAI) { // Accept FirebaseAI instance
       model = firebaseService.generativeModel(
-          modelName: "gemini-2.0-flash-001",
+        modelName: "gemini-2.5-flash-lite",
           tools: [.functionDeclarations([
               FunctionDeclaration(
           name: "get_exchange_rate",

--- a/firebaseai/FirebaseAIExample/GenerativeAIMultimodalExample/ViewModels/PhotoReasoningViewModel.swift
+++ b/firebaseai/FirebaseAIExample/GenerativeAIMultimodalExample/ViewModels/PhotoReasoningViewModel.swift
@@ -48,7 +48,7 @@ class PhotoReasoningViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init(firebaseService: FirebaseAI) {
-    model = firebaseService.generativeModel(modelName: "gemini-2.0-flash-001")
+    model = firebaseService.generativeModel(modelName: "gemini-2.5-flash-lite")
   }
 
   func reason() async {

--- a/firebaseai/FirebaseAIExample/GenerativeAITextExample/ViewModels/GenerateContentViewModel.swift
+++ b/firebaseai/FirebaseAIExample/GenerativeAITextExample/ViewModels/GenerateContentViewModel.swift
@@ -36,7 +36,7 @@ class GenerateContentViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init(firebaseService: FirebaseAI) {
-    model = firebaseService.generativeModel(modelName: "gemini-2.0-flash-001")
+    model = firebaseService.generativeModel(modelName: "gemini-2.5-flash-lite")
   }
 
   func generateContent(inputText: String) async {

--- a/firebaseai/FirebaseAIExample/ImagenExample/ImagenViewModel.swift
+++ b/firebaseai/FirebaseAIExample/ImagenExample/ImagenViewModel.swift
@@ -42,13 +42,13 @@ class ImagenViewModel: ObservableObject {
   private var generateImagesTask: Task<Void, Never>?
 
   init(firebaseService: FirebaseAI) {
-    let modelName = "imagen-3.0-generate-002"
+    let modelName = "imagen-4.0-fast-generate-001"
     let safetySettings = ImagenSafetySettings(
       safetyFilterLevel: .blockLowAndAbove
     )
     var generationConfig = ImagenGenerationConfig()
     generationConfig.numberOfImages = 4
-    generationConfig.aspectRatio = .landscape4x3
+    generationConfig.aspectRatio = .square1x1
 
     model = firebaseService.imagenModel(
       modelName: modelName,


### PR DESCRIPTION
Replaced `gemini-2.0-flash-001` with `gemini-2.5-flash-lite` and, more importantly, replaced `imagen-3.0-generate-002` with `imagen-4.0-fast-generate-001`. Imagen 3 is [deprecated on the Gemini Developer API](https://ai.google.dev/gemini-api/docs/deprecations#:~:text=Imagen%203,Use%20Imagen%204.) as of 2025-11-10.