### PR TITLE
fix: use `-destination` instead of `-sdk` in `scripts/build-for-testing.sh`

### DIFF
--- a/scripts/build-for-testing.sh
+++ b/scripts/build-for-testing.sh
@@ -93,7 +93,7 @@ flags+=( -scheme "$SCHEME" )
 
 # Set derivedDataPath
 DERIVEDDATAPATH="build-for-testing/${SCHEME}"
-flags+=( -sdk "iphoneos" -derivedDataPath "$DERIVEDDATAPATH")
+flags+=( -destination "generic/platform=iOS" -derivedDataPath "$DERIVEDDATAPATH")
 
 # Add extra flags
 if [[ "$SAMPLE" == Config ]];then
@@ -120,7 +120,7 @@ function xcb() {
 }
 
 # Run xcodebuild
-sudo xcode-select -p
+xcode-select -p
 xcb "${flags[@]}"
 echo "$message"
 


### PR DESCRIPTION
The -destination flag let's Xcode decide which SDK to build against. It fixes an issue where Crashlytics tests weren't building because of the linked watchOS app embedded in the iOS target. 

Fixes the Crashlytics tests: https://github.com/firebase/firebase-ios-sdk/actions/runs/19710483584/job/56469451688?pr=15545

Other FTL crons should be unaffected