### PR TITLE
fix(auth): quick fix for Auth.User sendability error

### DIFF
--- a/authentication/AuthenticationExample/ViewControllers/UserViewController.swift
+++ b/authentication/AuthenticationExample/ViewControllers/UserViewController.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import UIKit
+// TODO: Remove @preconcurrency once `FirebaseAuth.User` is Sendable
 @preconcurrency import FirebaseAuth
 import AuthenticationServices
 import CryptoKit

--- a/authentication/AuthenticationExample/ViewControllers/UserViewController.swift
+++ b/authentication/AuthenticationExample/ViewControllers/UserViewController.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import UIKit
-import FirebaseAuth
+@preconcurrency import FirebaseAuth
 import AuthenticationServices
 import CryptoKit
 


### PR DESCRIPTION
```
/Users/nickcooke/Developer/quickstart-ios/authentication/AuthenticationExample/ViewControllers/UserViewController.swift:303:25: error: sending 'self.user.some' risks causing data races
        try await user?.delete()
                  ~~~~~~^~~~~~~~
/Users/nickcooke/Developer/quickstart-ios/authentication/AuthenticationExample/ViewControllers/UserViewController.swift:303:25: note: sending main actor-isolated 'self.user.some' to nonisolated instance method 'delete()' risks causing data races between nonisolated and main actor-isolated uses
        try await user?.delete()
```