### PR TITLE
feat(ai): migrate Imagen pages to Nano Banana

### DIFF
--- a/firebaseai/FirebaseAIExample/ContentView.swift
+++ b/firebaseai/FirebaseAIExample/ContentView.swift
@@ -98,10 +98,10 @@ struct ContentView: View {
     switch sample.navRoute {
     case "ChatScreen":
       ChatScreen(backendType: selectedBackend, sample: sample)
-    case "ImagenScreen":
-      ImagenScreen(backendType: selectedBackend, sample: sample)
-    case "ImagenFromTemplateScreen":
-      ImagenFromTemplateScreen(backendType: selectedBackend, sample: sample)
+    case "NanoBananaScreen":
+      NanoBananaScreen(backendType: selectedBackend, sample: sample)
+    case "NanoBananaFromTemplateScreen":
+      NanoBananaFromTemplateScreen(backendType: selectedBackend, sample: sample)
     case "GenerateContentFromTemplateScreen":
       GenerateContentFromTemplateScreen(backendType: selectedBackend, sample: sample)
     case "MultimodalScreen":

--- a/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaFromTemplateScreen.swift
+++ b/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaFromTemplateScreen.swift
@@ -28,7 +28,7 @@ struct NanoBananaFromTemplateScreen: View {
     self.backendType = backendType
     _viewModel =
       StateObject(wrappedValue: NanoBananaFromTemplateViewModel(backendType: backendType,
-                                                            sample: sample))
+                                                                sample: sample))
   }
 
   enum FocusedField: Hashable {

--- a/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaFromTemplateScreen.swift
+++ b/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaFromTemplateScreen.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,18 +20,15 @@ import SwiftUI
 #endif
 import ConversationKit
 
-struct ImagenScreen: View {
+struct NanoBananaFromTemplateScreen: View {
   let backendType: BackendOption
-  @StateObject var viewModel: ImagenViewModel
-
-  @State
-  private var userPrompt = ""
+  @StateObject var viewModel: NanoBananaFromTemplateViewModel
 
   init(backendType: BackendOption, sample: Sample? = nil) {
     self.backendType = backendType
     _viewModel =
-      StateObject(wrappedValue: ImagenViewModel(backendType: backendType,
-                                                sample: sample))
+      StateObject(wrappedValue: NanoBananaFromTemplateViewModel(backendType: backendType,
+                                                            sample: sample))
   }
 
   enum FocusedField: Hashable {
@@ -45,7 +42,7 @@ struct ImagenScreen: View {
     ZStack {
       ScrollView {
         VStack {
-          MessageComposerView(message: $userPrompt)
+          MessageComposerView(message: $viewModel.userInput)
             .padding(.bottom, 10)
             .focused($focusedField, equals: .message)
             .disableAttachments()
@@ -89,19 +86,16 @@ struct ImagenScreen: View {
         ErrorDetailsView(error: error)
       }
     }
-    .navigationTitle("Imagen example")
+    .navigationTitle("Nano Banana Template")
     .navigationBarTitleDisplayMode(.inline)
     .onAppear {
       focusedField = .message
-      if userPrompt.isEmpty && !viewModel.initialPrompt.isEmpty {
-        userPrompt = viewModel.initialPrompt
-      }
     }
   }
 
   private func sendMessage() {
     Task {
-      await viewModel.generateImage(prompt: userPrompt)
+      await viewModel.generateImageFromTemplate(prompt: viewModel.userInput)
       focusedField = .message
     }
   }
@@ -116,5 +110,5 @@ struct ImagenScreen: View {
 }
 
 #Preview {
-  ImagenScreen(backendType: .googleAI)
+  NanoBananaFromTemplateScreen(backendType: .googleAI)
 }

--- a/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaFromTemplateViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaFromTemplateViewModel.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,16 +18,29 @@
   import FirebaseAI
 #endif
 import Foundation
-import Combine
 import OSLog
 import SwiftUI
+import Combine
+
+// Template Details
+//
+//  Configuration
+//
+//    input:
+//      schema:
+//        prompt: 'string'
+//
+//  Prompt and system instructions
+//
+//    Create an image containing {{prompt}}
+//
 
 @MainActor
-class ImagenViewModel: ObservableObject {
+class NanoBananaFromTemplateViewModel: ObservableObject {
   private var logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "generative-ai")
 
   @Published
-  var initialPrompt: String = ""
+  var userInput: String = ""
 
   @Published
   var images = [UIImage]()
@@ -44,7 +57,7 @@ class ImagenViewModel: ObservableObject {
   @Published
   var inProgress = false
 
-  private let model: ImagenModel
+  private let model: TemplateGenerativeModel
   private var backendType: BackendOption
 
   private var generateImagesTask: Task<Void, Never>?
@@ -59,24 +72,10 @@ class ImagenViewModel: ObservableObject {
       ? FirebaseAI.firebaseAI(backend: .googleAI())
       : FirebaseAI.firebaseAI(backend: .vertexAI())
 
-    let modelName = "imagen-4.0-generate-001"
-    let safetySettings = ImagenSafetySettings(
-      safetyFilterLevel: .blockLowAndAbove
-    )
-    var generationConfig = ImagenGenerationConfig()
-    generationConfig.numberOfImages = 4
-    generationConfig.aspectRatio = .square1x1
-
-    model = firebaseService.imagenModel(
-      modelName: modelName,
-      generationConfig: generationConfig,
-      safetySettings: safetySettings
-    )
-
-    initialPrompt = sample?.initialPrompt ?? ""
+    model = firebaseService.templateGenerativeModel()
   }
 
-  func generateImage(prompt: String) async {
+  func generateImageFromTemplate(prompt: String) async {
     stop()
 
     generateImagesTask = Task {
@@ -86,22 +85,27 @@ class ImagenViewModel: ObservableObject {
       }
 
       do {
-        // 1. Call generateImages with the text prompt
-        let response = try await model.generateImages(prompt: prompt)
+        // 1. Call generateContent with the text prompt
+        let response = try await model.generateContent(
+          templateID: "nanobanana-generation-basic",
+          inputs: [
+            "prompt": prompt,
+          ]
+        )
 
-        // 2. Print the reason images were filtered out, if any.
-        if let filteredReason = response.filteredReason {
-          print("Image(s) Blocked: \(filteredReason)")
+        // 2. Print the reason images were blocked, if any.
+        if let blockReason = response.promptFeedback?.blockReason {
+          print("Image(s) Blocked: \(blockReason)")
         }
 
         if !Task.isCancelled {
           // 3. Convert the image data to UIImage for display in the UI
-          images = response.images.compactMap { UIImage(data: $0.data) }
+          images = response.inlineDataParts.compactMap { UIImage(data: $0.data) }
         }
       } catch {
         if !Task.isCancelled {
           self.error = error
-          logger.error("Error generating images: \(error)")
+          logger.error("Error generating images from template: \(error)")
         }
       }
     }

--- a/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaScreen.swift
+++ b/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaScreen.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,15 +20,18 @@ import SwiftUI
 #endif
 import ConversationKit
 
-struct ImagenFromTemplateScreen: View {
+struct NanoBananaScreen: View {
   let backendType: BackendOption
-  @StateObject var viewModel: ImagenFromTemplateViewModel
+  @StateObject var viewModel: NanoBananaViewModel
+
+  @State
+  private var userPrompt = ""
 
   init(backendType: BackendOption, sample: Sample? = nil) {
     self.backendType = backendType
     _viewModel =
-      StateObject(wrappedValue: ImagenFromTemplateViewModel(backendType: backendType,
-                                                            sample: sample))
+      StateObject(wrappedValue: NanoBananaViewModel(backendType: backendType,
+                                                sample: sample))
   }
 
   enum FocusedField: Hashable {
@@ -42,7 +45,7 @@ struct ImagenFromTemplateScreen: View {
     ZStack {
       ScrollView {
         VStack {
-          MessageComposerView(message: $viewModel.userInput)
+          MessageComposerView(message: $userPrompt)
             .padding(.bottom, 10)
             .focused($focusedField, equals: .message)
             .disableAttachments()
@@ -86,16 +89,19 @@ struct ImagenFromTemplateScreen: View {
         ErrorDetailsView(error: error)
       }
     }
-    .navigationTitle("Imagen Template")
+    .navigationTitle("Nano Banana example")
     .navigationBarTitleDisplayMode(.inline)
     .onAppear {
       focusedField = .message
+      if userPrompt.isEmpty && !viewModel.initialPrompt.isEmpty {
+        userPrompt = viewModel.initialPrompt
+      }
     }
   }
 
   private func sendMessage() {
     Task {
-      await viewModel.generateImageFromTemplate(prompt: viewModel.userInput)
+      await viewModel.generateImage(prompt: userPrompt)
       focusedField = .message
     }
   }
@@ -110,5 +116,5 @@ struct ImagenFromTemplateScreen: View {
 }
 
 #Preview {
-  ImagenFromTemplateScreen(backendType: .googleAI)
+  NanoBananaScreen(backendType: .googleAI)
 }

--- a/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaScreen.swift
+++ b/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaScreen.swift
@@ -31,7 +31,7 @@ struct NanoBananaScreen: View {
     self.backendType = backendType
     _viewModel =
       StateObject(wrappedValue: NanoBananaViewModel(backendType: backendType,
-                                                sample: sample))
+                                                    sample: sample))
   }
 
   enum FocusedField: Hashable {

--- a/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaViewModel.swift
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,29 +18,16 @@
   import FirebaseAI
 #endif
 import Foundation
+import Combine
 import OSLog
 import SwiftUI
-import Combine
-
-// Template Details
-//
-//  Configuration
-//
-//    input:
-//      schema:
-//        prompt: 'string'
-//
-//  Prompt and system instructions
-//
-//    Create an image containing {{prompt}}
-//
 
 @MainActor
-class ImagenFromTemplateViewModel: ObservableObject {
+class NanoBananaViewModel: ObservableObject {
   private var logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "generative-ai")
 
   @Published
-  var userInput: String = ""
+  var initialPrompt: String = ""
 
   @Published
   var images = [UIImage]()
@@ -57,7 +44,7 @@ class ImagenFromTemplateViewModel: ObservableObject {
   @Published
   var inProgress = false
 
-  private let model: TemplateImagenModel
+  private let model: GenerativeModel
   private var backendType: BackendOption
 
   private var generateImagesTask: Task<Void, Never>?
@@ -72,10 +59,40 @@ class ImagenFromTemplateViewModel: ObservableObject {
       ? FirebaseAI.firebaseAI(backend: .googleAI())
       : FirebaseAI.firebaseAI(backend: .vertexAI())
 
-    model = firebaseService.templateImagenModel()
+    let modelName = "gemini-2.5-flash-image"
+    let safetySettings = [
+      SafetySetting(
+        harmCategory: .civicIntegrity,
+        threshold: .blockLowAndAbove
+      ),
+      SafetySetting(
+        harmCategory: .dangerousContent,
+        threshold: .blockLowAndAbove
+      ),
+      SafetySetting(
+        harmCategory: .harassment,
+        threshold: .blockLowAndAbove
+      ),
+      SafetySetting(
+        harmCategory: .hateSpeech,
+        threshold: .blockLowAndAbove
+      ),
+      SafetySetting(
+        harmCategory: .sexuallyExplicit,
+        threshold: .blockLowAndAbove
+      )
+    ]
+
+    model = firebaseService.generativeModel(
+      modelName: modelName,
+      generationConfig: GenerationConfig(responseModalities: [.image]),
+      safetySettings: safetySettings
+    )
+
+    initialPrompt = sample?.initialPrompt ?? ""
   }
 
-  func generateImageFromTemplate(prompt: String) async {
+  func generateImage(prompt: String) async {
     stop()
 
     generateImagesTask = Task {
@@ -85,27 +102,22 @@ class ImagenFromTemplateViewModel: ObservableObject {
       }
 
       do {
-        // 1. Call generateImages with the text prompt
-        let response = try await model.generateImages(
-          templateID: "imagen-generation-basic",
-          inputs: [
-            "prompt": prompt,
-          ]
-        )
+        // 1. Call generateContent with the text prompt
+        let response = try await model.generateContent(prompt)
 
-        // 2. Print the reason images were filtered out, if any.
-        if let filteredReason = response.filteredReason {
-          print("Image(s) Blocked: \(filteredReason)")
+        // 2. Print the reason images were blocked, if any.
+        if let blockReason = response.promptFeedback?.blockReason {
+          print("Image(s) Blocked: \(blockReason)")
         }
 
         if !Task.isCancelled {
           // 3. Convert the image data to UIImage for display in the UI
-          images = response.images.compactMap { UIImage(data: $0.data) }
+          images = response.inlineDataParts.compactMap { UIImage(data: $0.data) }
         }
       } catch {
         if !Task.isCancelled {
           self.error = error
-          logger.error("Error generating images from template: \(error)")
+          logger.error("Error generating images: \(error)")
         }
       }
     }

--- a/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/NanoBanana/NanoBananaViewModel.swift
@@ -80,7 +80,7 @@ class NanoBananaViewModel: ObservableObject {
       SafetySetting(
         harmCategory: .sexuallyExplicit,
         threshold: .blockLowAndAbove
-      )
+      ),
     ]
 
     model = firebaseService.generativeModel(

--- a/firebaseai/FirebaseAIExample/Shared/Models/Sample.swift
+++ b/firebaseai/FirebaseAIExample/Shared/Models/Sample.swift
@@ -131,7 +131,7 @@ extension Sample {
       ]
     ),
     Sample(
-      title: "Nanao Banana - image generation",
+      title: "Nano Banana - image generation",
       description: "Generate images using Nano Banana 2",
       useCases: [.image],
       navRoute: "NanoBananaScreen",

--- a/firebaseai/FirebaseAIExample/Shared/Models/Sample.swift
+++ b/firebaseai/FirebaseAIExample/Shared/Models/Sample.swift
@@ -131,17 +131,17 @@ extension Sample {
       ]
     ),
     Sample(
-      title: "Imagen - image generation",
-      description: "Generate images using Imagen 3",
+      title: "Nanao Banana - image generation",
+      description: "Generate images using Nano Banana 2",
       useCases: [.image],
-      navRoute: "ImagenScreen",
+      navRoute: "NanoBananaScreen",
       initialPrompt: "A photo of a modern building with water in the background"
     ),
     Sample(
-      title: "[T] Imagen - image generation",
-      description: "[T] Generate images using Imagen 3",
+      title: "[T] Nano Banana - image generation",
+      description: "[T] Generate images using Nano Banana 2",
       useCases: [.image],
-      navRoute: "ImagenFromTemplateScreen",
+      navRoute: "NanoBananaFromTemplateScreen",
       initialPrompt: "A photo of a modern building with water in the background"
     ),
     Sample(


### PR DESCRIPTION
Per [b/498982262](https://b.corp.google.com/issues/498982262),

This PR migrates all of our existing Imagen screens to Nano Banana alternatives. This aligns with the deprecation of the Imagen API, and should offer consumers a prime example of what migration looks like.

Note that for the template, I created a template in the Firebase console that matched the Imagen one. Although, since there's not a default dropdown for a Nano Banana template, I'd be fine with just removing that screen entirely.