### PR TITLE
Use minimum supported Xcode for AI QS CI

### DIFF
--- a/.github/workflows/firebaseai.yml
+++ b/.github/workflows/firebaseai.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           - os: macos-26
-            xcode: "26.1"
+            xcode: "26.2"
             platform: iOS
             device: iPhone 17 Pro
             ios_version: "26.1"


### PR DESCRIPTION
See nightly CI failure https://github.com/firebase/quickstart-ios/actions/runs/24123724657/job/70383310746