### PR TITLE
fix(ai): fix compile error due to session resumption

### DIFF
--- a/firebaseai/FirebaseAIExample.xcodeproj/project.pbxproj
+++ b/firebaseai/FirebaseAIExample.xcodeproj/project.pbxproj
@@ -374,7 +374,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 12.6.0;
+				minimumVersion = 12.13.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/firebaseai/FirebaseAIExample/Features/Live/ViewModels/LiveViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/Live/ViewModels/LiveViewModel.swift
@@ -200,7 +200,7 @@ class LiveViewModel: ObservableObject {
     case .toolCallCancellation:
       // we don't have any long running functions to cancel
       return
-    case .sessionResumptionUpdate:
+    case .sessionResumptionUpdate(_):
       // we don't do any session resumption here
       return
     case let .goingAwayNotice(goingAwayNotice):

--- a/firebaseai/FirebaseAIExample/Features/Live/ViewModels/LiveViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/Live/ViewModels/LiveViewModel.swift
@@ -200,7 +200,7 @@ class LiveViewModel: ObservableObject {
     case .toolCallCancellation:
       // we don't have any long running functions to cancel
       return
-    case .sessionResumptionUpdate(_):
+    case .sessionResumptionUpdate:
       // we don't do any session resumption here
       return
     case let .goingAwayNotice(goingAwayNotice):

--- a/firebaseai/FirebaseAIExample/Features/Live/ViewModels/LiveViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/Live/ViewModels/LiveViewModel.swift
@@ -200,6 +200,9 @@ class LiveViewModel: ObservableObject {
     case .toolCallCancellation:
       // we don't have any long running functions to cancel
       return
+    case .sessionResumptionUpdate:
+      // we don't do any session resumption here
+      return
     case let .goingAwayNotice(goingAwayNotice):
       let time = goingAwayNotice.timeLeft?.description ?? "soon"
       logger.warning("Going away in: \(time)")


### PR DESCRIPTION
Per [b/507503421](https://buganizer.corp.google.com/issues/507503421),

This PR updates the `LiveViewModel` match case on the response payload to also have a case for `. sessionResumptionUpdate` (which was added with [firebase-ios-sdk#15904](https://github.com/firebase/firebase-ios-sdk/pull/15904)), to fix the compile errors caused from a non exhaustive switch statement.

This PR also bumps the min version to align with the `12.13.0` release, so it can properly take advantage of this change.