### PR TITLE
fix(ai): migrate live models to 3.1

### DIFF
--- a/firebaseai/FirebaseAIExample/Features/Live/ViewModels/LiveViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/Live/ViewModels/LiveViewModel.swift
@@ -69,11 +69,11 @@ class LiveViewModel: ObservableObject {
   init(backendType: BackendOption, sample: Sample? = nil) {
     let firebaseService = backendType == .googleAI
       ? FirebaseAI.firebaseAI(backend: .googleAI())
-      : FirebaseAI.firebaseAI(backend: .vertexAI(location: "global"))
+      : FirebaseAI.firebaseAI(backend: .vertexAI(location: "us-central1"))
 
     model = firebaseService.liveModel(
-      modelName: (backendType == .googleAI) ? "gemini-2.5-flash-native-audio-preview-09-2025" :
-        "gemini-live-2.5-flash-preview-native-audio-09-2025",
+      modelName: (backendType == .googleAI) ? "gemini-3.1-flash-live-preview" :
+        "gemini-live-2.5-flash-native-audio",
       generationConfig: sample?.liveGenerationConfig,
       tools: sample?.tools,
       systemInstruction: sample?.systemInstruction
@@ -206,9 +206,6 @@ class LiveViewModel: ObservableObject {
     case let .goingAwayNotice(goingAwayNotice):
       let time = goingAwayNotice.timeLeft?.description ?? "soon"
       logger.warning("Going away in: \(time)")
-    default:
-      // TODO: Remove default case after merging #1852
-      return
     }
   }
 


### PR DESCRIPTION
Per [b/529424361](https://b.corp.google.com/issues/529424361),

This updates the live screens to use the new `gemini-3.1-flash-live-preview` models instead of the old `2.5` models. This has been tested on a physical device, and everything seems to still be working properly.

Although, the Vertex API doesn't seem to support `gemini-3.1-flash-live-preview` right now. Their docs _do_ say that the `2.5` preview model is deprecated and removed, and you should instead use `gemini-live-2.5-flash-native-audio` though. So I've migrated the live vertex models to `gemini-live-2.5-flash-native-audio`. Furthermore, vertex doesn't support the global endpoint for this model, so I've changed the location back to `us-central1` for this case.

This PR also removes the old `default` case we had in this file from a previous release.