### PR TITLE
fix(apple-ai): wrap FoundationModels code in canImport check to fix CI build

### DIFF
--- a/firebaseai/FirebaseAIExample/ContentView.swift
+++ b/firebaseai/FirebaseAIExample/ContentView.swift
@@ -131,23 +131,23 @@ struct ContentView: View {
       LiveScreen(backendType: selectedBackend, sample: sample)
     case "FoundationModelsHybrid":
       #if canImport(FoundationModels)
-      if #available(iOS 27.0, *) {
-        HybridAIScreen(backendType: selectedBackend)
-      } else {
-        Text("Foundation Models are only available on iOS 27 or newer.")
-      }
+        if #available(iOS 27.0, *) {
+          HybridAIScreen(backendType: selectedBackend)
+        } else {
+          Text("Foundation Models are only available on iOS 27 or newer.")
+        }
       #else
-      Text("Foundation Models are not supported on this platform/SDK.")
+        Text("Foundation Models are not supported on this platform/SDK.")
       #endif
     case "FoundationModelsVisionID":
       #if canImport(FoundationModels)
-      if #available(iOS 27.0, *) {
-        VisionIDScreen(backendType: selectedBackend)
-      } else {
-        Text("Foundation Models are only available on iOS 27 or newer.")
-      }
+        if #available(iOS 27.0, *) {
+          VisionIDScreen(backendType: selectedBackend)
+        } else {
+          Text("Foundation Models are only available on iOS 27 or newer.")
+        }
       #else
-      Text("Foundation Models are not supported on this platform/SDK.")
+        Text("Foundation Models are not supported on this platform/SDK.")
       #endif
     default:
       EmptyView()

--- a/firebaseai/FirebaseAIExample/ContentView.swift
+++ b/firebaseai/FirebaseAIExample/ContentView.swift
@@ -130,7 +130,7 @@ struct ContentView: View {
     case "LiveScreen":
       LiveScreen(backendType: selectedBackend, sample: sample)
     case "FoundationModelsHybrid":
-      #if canImport(FoundationModels)
+      #if canImport(FoundationModels) && compiler(>=6.4)
         if #available(iOS 27.0, *) {
           HybridAIScreen(backendType: selectedBackend)
         } else {
@@ -140,7 +140,7 @@ struct ContentView: View {
         Text("Foundation Models are not supported on this platform/SDK.")
       #endif
     case "FoundationModelsVisionID":
-      #if canImport(FoundationModels)
+      #if canImport(FoundationModels) && compiler(>=6.4)
         if #available(iOS 27.0, *) {
           VisionIDScreen(backendType: selectedBackend)
         } else {

--- a/firebaseai/FirebaseAIExample/ContentView.swift
+++ b/firebaseai/FirebaseAIExample/ContentView.swift
@@ -130,17 +130,25 @@ struct ContentView: View {
     case "LiveScreen":
       LiveScreen(backendType: selectedBackend, sample: sample)
     case "FoundationModelsHybrid":
+      #if canImport(FoundationModels)
       if #available(iOS 27.0, *) {
         HybridAIScreen(backendType: selectedBackend)
       } else {
         Text("Foundation Models are only available on iOS 27 or newer.")
       }
+      #else
+      Text("Foundation Models are not supported on this platform/SDK.")
+      #endif
     case "FoundationModelsVisionID":
+      #if canImport(FoundationModels)
       if #available(iOS 27.0, *) {
         VisionIDScreen(backendType: selectedBackend)
       } else {
         Text("Foundation Models are only available on iOS 27 or newer.")
       }
+      #else
+      Text("Foundation Models are not supported on this platform/SDK.")
+      #endif
     default:
       EmptyView()
     }

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Models/Models.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Models/Models.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && compiler(>=6.4)
   import Foundation
   import FoundationModels
 

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Models/Models.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Models/Models.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationModels)
 import Foundation
 import FoundationModels
 
@@ -36,3 +37,4 @@ struct TextSummary: Equatable, Codable {
   @Guide(description: "A list of exactly 2 key summary points.")
   let summaryPoints: [String]
 }
+#endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Models/Models.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Models/Models.swift
@@ -13,28 +13,28 @@
 // limitations under the License.
 
 #if canImport(FoundationModels)
-import Foundation
-import FoundationModels
+  import Foundation
+  import FoundationModels
 
-@available(iOS 26.0, *)
-@Generable
-struct IdentifiedObject: Equatable, Codable {
-  @Guide(description: "The name of the primary object or landmark detected.")
-  let name: String
+  @available(iOS 26.0, *)
+  @Generable
+  struct IdentifiedObject: Equatable, Codable {
+    @Guide(description: "The name of the primary object or landmark detected.")
+    let name: String
 
-  @Guide(
-    description: "The category of the object (e.g. Landmark, Plant, Food, Animal, Device, Clothing)."
-  )
-  let category: String
+    @Guide(
+      description: "The category of the object (e.g. Landmark, Plant, Food, Animal, Device, Clothing)."
+    )
+    let category: String
 
-  @Guide(description: "A short, 2-sentence description of the object and interesting facts.")
-  let description: String
-}
+    @Guide(description: "A short, 2-sentence description of the object and interesting facts.")
+    let description: String
+  }
 
-@available(iOS 26.0, *)
-@Generable
-struct TextSummary: Equatable, Codable {
-  @Guide(description: "A list of exactly 2 key summary points.")
-  let summaryPoints: [String]
-}
+  @available(iOS 26.0, *)
+  @Generable
+  struct TextSummary: Equatable, Codable {
+    @Guide(description: "A list of exactly 2 key summary points.")
+    let summaryPoints: [String]
+  }
 #endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Screens/HybridAIScreen.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Screens/HybridAIScreen.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && compiler(>=6.4)
   import SwiftUI
 
   @available(iOS 27.0, *)

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Screens/HybridAIScreen.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Screens/HybridAIScreen.swift
@@ -13,20 +13,20 @@
 // limitations under the License.
 
 #if canImport(FoundationModels)
-import SwiftUI
+  import SwiftUI
 
-@available(iOS 27.0, *)
-struct HybridAIScreen: View {
-  @StateObject private var viewModel: HybridAIViewModel
+  @available(iOS 27.0, *)
+  struct HybridAIScreen: View {
+    @StateObject private var viewModel: HybridAIViewModel
 
-  init(backendType: BackendOption) {
-    _viewModel = StateObject(wrappedValue: HybridAIViewModel(backendType: backendType))
-  }
+    init(backendType: BackendOption) {
+      _viewModel = StateObject(wrappedValue: HybridAIViewModel(backendType: backendType))
+    }
 
-  var body: some View {
-    FoundationModelsContainer(viewModel: viewModel, title: "Hybrid AI") { vm in
-      HybridAIView(viewModel: vm)
+    var body: some View {
+      FoundationModelsContainer(viewModel: viewModel, title: "Hybrid AI") { vm in
+        HybridAIView(viewModel: vm)
+      }
     }
   }
-}
 #endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Screens/HybridAIScreen.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Screens/HybridAIScreen.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationModels)
 import SwiftUI
 
 @available(iOS 27.0, *)
@@ -28,3 +29,4 @@ struct HybridAIScreen: View {
     }
   }
 }
+#endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Screens/VisionIDScreen.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Screens/VisionIDScreen.swift
@@ -13,22 +13,22 @@
 // limitations under the License.
 
 #if canImport(FoundationModels)
-import SwiftUI
-import PhotosUI
+  import SwiftUI
+  import PhotosUI
 
-@available(iOS 27.0, *)
-struct VisionIDScreen: View {
-  @StateObject private var viewModel: VisionIDViewModel
-  @State private var photosPickerItem: PhotosPickerItem? = nil
+  @available(iOS 27.0, *)
+  struct VisionIDScreen: View {
+    @StateObject private var viewModel: VisionIDViewModel
+    @State private var photosPickerItem: PhotosPickerItem? = nil
 
-  init(backendType: BackendOption) {
-    _viewModel = StateObject(wrappedValue: VisionIDViewModel(backendType: backendType))
-  }
+    init(backendType: BackendOption) {
+      _viewModel = StateObject(wrappedValue: VisionIDViewModel(backendType: backendType))
+    }
 
-  var body: some View {
-    FoundationModelsContainer(viewModel: viewModel, title: "Vision ID") { vm in
-      VisionIDView(viewModel: vm, photosPickerItem: $photosPickerItem)
+    var body: some View {
+      FoundationModelsContainer(viewModel: viewModel, title: "Vision ID") { vm in
+        VisionIDView(viewModel: vm, photosPickerItem: $photosPickerItem)
+      }
     }
   }
-}
 #endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Screens/VisionIDScreen.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Screens/VisionIDScreen.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationModels)
 import SwiftUI
 import PhotosUI
 
@@ -30,3 +31,4 @@ struct VisionIDScreen: View {
     }
   }
 }
+#endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Screens/VisionIDScreen.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Screens/VisionIDScreen.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && compiler(>=6.4)
   import SwiftUI
   import PhotosUI
 

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/FoundationModelsBaseViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/FoundationModelsBaseViewModel.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationModels)
 import Foundation
 import SwiftUI
 import Combine
@@ -56,3 +57,4 @@ class FoundationModelsBaseViewModel: ObservableObject {
     }
   }
 }
+#endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/FoundationModelsBaseViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/FoundationModelsBaseViewModel.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && compiler(>=6.4)
   import Foundation
   import SwiftUI
   import Combine

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/FoundationModelsBaseViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/FoundationModelsBaseViewModel.swift
@@ -13,48 +13,48 @@
 // limitations under the License.
 
 #if canImport(FoundationModels)
-import Foundation
-import SwiftUI
-import Combine
-import FoundationModels
-import FirebaseAILogic
+  import Foundation
+  import SwiftUI
+  import Combine
+  import FoundationModels
+  import FirebaseAILogic
 
-enum ModelPreference: String, CaseIterable, Identifiable {
-  case auto = "Auto (Local First)"
-  case cloud = "Cloud Only"
+  enum ModelPreference: String, CaseIterable, Identifiable {
+    case auto = "Auto (Local First)"
+    case cloud = "Cloud Only"
 
-  var id: String { rawValue }
-}
-
-@available(iOS 27.0, *)
-@MainActor
-class FoundationModelsBaseViewModel: ObservableObject {
-  @Published var inProgress = false
-  @Published var error: Error?
-  @Published var modelPreference: ModelPreference = .auto
-  @Published var isUsingLocalModel: Bool = false
-
-  internal var activeTask: Task<Void, Never>?
-  let backendType: BackendOption
-
-  init(backendType: BackendOption) {
-    self.backendType = backendType
+    var id: String { rawValue }
   }
 
-  func stopActiveTask() {
-    activeTask?.cancel()
-    activeTask = nil
-    inProgress = false
-  }
+  @available(iOS 27.0, *)
+  @MainActor
+  class FoundationModelsBaseViewModel: ObservableObject {
+    @Published var inProgress = false
+    @Published var error: Error?
+    @Published var modelPreference: ModelPreference = .auto
+    @Published var isUsingLocalModel: Bool = false
 
-  internal func getFirebaseAI() -> FirebaseAI {
-    switch backendType {
-    case .googleAI:
-      return FirebaseAI.firebaseAI(backend: .googleAI())
-    case .vertexAI:
-      // Using "global" as location for Foundation Models fallback compatibility
-      return FirebaseAI.firebaseAI(backend: .vertexAI(location: "global"))
+    internal var activeTask: Task<Void, Never>?
+    let backendType: BackendOption
+
+    init(backendType: BackendOption) {
+      self.backendType = backendType
+    }
+
+    func stopActiveTask() {
+      activeTask?.cancel()
+      activeTask = nil
+      inProgress = false
+    }
+
+    internal func getFirebaseAI() -> FirebaseAI {
+      switch backendType {
+      case .googleAI:
+        return FirebaseAI.firebaseAI(backend: .googleAI())
+      case .vertexAI:
+        // Using "global" as location for Foundation Models fallback compatibility
+        return FirebaseAI.firebaseAI(backend: .vertexAI(location: "global"))
+      }
     }
   }
-}
 #endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/HybridAIViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/HybridAIViewModel.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && compiler(>=6.4)
   import Foundation
   import SwiftUI
   import Combine

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/HybridAIViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/HybridAIViewModel.swift
@@ -58,6 +58,7 @@
             }
             return
           } catch {
+            guard !Task.isCancelled else { return }
             // Fall back to cloud model if local model fails
             if error.isMLAssetUnavailable {
               print("Local ML assets unavailable. Falling back to cloud model...")

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/HybridAIViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/HybridAIViewModel.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationModels)
 import Foundation
 import SwiftUI
 import Combine
@@ -92,3 +93,4 @@ final class HybridAIViewModel: FoundationModelsBaseViewModel {
     }
   }
 }
+#endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/HybridAIViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/HybridAIViewModel.swift
@@ -13,40 +13,69 @@
 // limitations under the License.
 
 #if canImport(FoundationModels)
-import Foundation
-import SwiftUI
-import Combine
-import FoundationModels
-import FirebaseAILogic
+  import Foundation
+  import SwiftUI
+  import Combine
+  import FoundationModels
+  import FirebaseAILogic
 
-@available(iOS 27.0, *)
-@MainActor
-final class HybridAIViewModel: FoundationModelsBaseViewModel {
-  @Published var inputText: String =
-    "It is the quintessential autumn harvest fruit, famously baked into warm cinnamon pastries, dipped in sticky caramel on Halloween, and traditionally rumored to keep medical professionals at bay if eaten once a day."
-  @Published var outputSummary: TextSummary?
+  @available(iOS 27.0, *)
+  @MainActor
+  final class HybridAIViewModel: FoundationModelsBaseViewModel {
+    @Published var inputText: String =
+      "It is the quintessential autumn harvest fruit, famously baked into warm cinnamon pastries, dipped in sticky caramel on Halloween, and traditionally rumored to keep medical professionals at bay if eaten once a day."
+    @Published var outputSummary: TextSummary?
 
-  func runSummarization() {
-    stopActiveTask()
-    inProgress = true
-    error = nil
-    outputSummary = nil
+    func runSummarization() {
+      stopActiveTask()
+      inProgress = true
+      error = nil
+      outputSummary = nil
 
-    activeTask = Task {
-      defer { self.inProgress = false }
+      activeTask = Task {
+        defer { self.inProgress = false }
 
-      let instructions = Instructions {
-        "Your job is to summarize the provided text in exactly 2 bullet points."
-      }
+        let instructions = Instructions {
+          "Your job is to summarize the provided text in exactly 2 bullet points."
+        }
 
-      let availability = SystemLanguageModel.default.availability
+        let availability = SystemLanguageModel.default.availability
 
-      // Try local model first if it reports available and not forced to cloud
-      if modelPreference == .auto, availability == .available {
-        isUsingLocalModel = true
+        // Try local model first if it reports available and not forced to cloud
+        if modelPreference == .auto, availability == .available {
+          isUsingLocalModel = true
+          do {
+            let session = LanguageModelSession(
+              model: SystemLanguageModel.default,
+              instructions: instructions
+            )
+            let response = try await session.respond(
+              to: inputText,
+              generating: TextSummary.self
+            )
+            if !Task.isCancelled {
+              self.outputSummary = response.content
+            }
+            return
+          } catch {
+            // Fall back to cloud model if local model fails
+            if error.isMLAssetUnavailable {
+              print("Local ML assets unavailable. Falling back to cloud model...")
+            } else {
+              print(
+                "Local model failed: \(error.localizedDescription). Falling back to cloud model..."
+              )
+            }
+          }
+        }
+
+        // Fallback to cloud model
+        isUsingLocalModel = false
         do {
+          let ai = getFirebaseAI()
+          let model = ai.geminiLanguageModel(name: "gemini-3.1-flash-lite")
           let session = LanguageModelSession(
-            model: SystemLanguageModel.default,
+            model: model,
             instructions: instructions
           )
           let response = try await session.respond(
@@ -56,41 +85,12 @@ final class HybridAIViewModel: FoundationModelsBaseViewModel {
           if !Task.isCancelled {
             self.outputSummary = response.content
           }
-          return
         } catch {
-          // Fall back to cloud model if local model fails
-          if error.isMLAssetUnavailable {
-            print("Local ML assets unavailable. Falling back to cloud model...")
-          } else {
-            print(
-              "Local model failed: \(error.localizedDescription). Falling back to cloud model..."
-            )
+          if !Task.isCancelled {
+            self.error = error
           }
-        }
-      }
-
-      // Fallback to cloud model
-      isUsingLocalModel = false
-      do {
-        let ai = getFirebaseAI()
-        let model = ai.geminiLanguageModel(name: "gemini-3.1-flash-lite")
-        let session = LanguageModelSession(
-          model: model,
-          instructions: instructions
-        )
-        let response = try await session.respond(
-          to: inputText,
-          generating: TextSummary.self
-        )
-        if !Task.isCancelled {
-          self.outputSummary = response.content
-        }
-      } catch {
-        if !Task.isCancelled {
-          self.error = error
         }
       }
     }
   }
-}
 #endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/VisionIDViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/VisionIDViewModel.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && compiler(>=6.4)
   import Foundation
   import SwiftUI
   import Combine

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/VisionIDViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/VisionIDViewModel.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationModels)
 import Foundation
 import SwiftUI
 import Combine
@@ -101,3 +102,4 @@ final class VisionIDViewModel: FoundationModelsBaseViewModel {
     }
   }
 }
+#endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/VisionIDViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/VisionIDViewModel.swift
@@ -63,6 +63,7 @@
             }
             return
           } catch {
+            guard !Task.isCancelled else { return }
             if error.isMLAssetUnavailable {
               print(
                 "Local ML assets unavailable for Vision ID. Falling back to cloud model..."

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/VisionIDViewModel.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/ViewModels/VisionIDViewModel.swift
@@ -13,43 +13,75 @@
 // limitations under the License.
 
 #if canImport(FoundationModels)
-import Foundation
-import SwiftUI
-import Combine
-import FoundationModels
-import FirebaseAILogic
+  import Foundation
+  import SwiftUI
+  import Combine
+  import FoundationModels
+  import FirebaseAILogic
 
-@available(iOS 27.0, *)
-@MainActor
-final class VisionIDViewModel: FoundationModelsBaseViewModel {
-  @Published var selectedImage: UIImage?
-  @Published var identifiedObject: IdentifiedObject?
+  @available(iOS 27.0, *)
+  @MainActor
+  final class VisionIDViewModel: FoundationModelsBaseViewModel {
+    @Published var selectedImage: UIImage?
+    @Published var identifiedObject: IdentifiedObject?
 
-  func identifySelectedImage() {
-    guard let image = selectedImage else { return }
-    stopActiveTask()
-    inProgress = true
-    error = nil
-    identifiedObject = nil
-    isUsingLocalModel = false
+    func identifySelectedImage() {
+      guard let image = selectedImage else { return }
+      stopActiveTask()
+      inProgress = true
+      error = nil
+      identifiedObject = nil
+      isUsingLocalModel = false
 
-    activeTask = Task {
-      defer { self.inProgress = false }
+      activeTask = Task {
+        defer { self.inProgress = false }
 
-      guard let cgImage = image.cgImage else { return }
+        guard let cgImage = image.cgImage else { return }
 
-      let instructions = Instructions {
-        "You are a visual object identifier."
-      }
+        let instructions = Instructions {
+          "You are a visual object identifier."
+        }
 
-      let availability = SystemLanguageModel.default.availability
+        let availability = SystemLanguageModel.default.availability
 
-      // Try local model first if it reports available and not forced to cloud
-      if modelPreference == .auto, availability == .available {
-        isUsingLocalModel = true
+        // Try local model first if it reports available and not forced to cloud
+        if modelPreference == .auto, availability == .available {
+          isUsingLocalModel = true
+          do {
+            let session = LanguageModelSession(
+              model: SystemLanguageModel.default,
+              instructions: instructions
+            )
+            let response = try await session.respond(
+              generating: IdentifiedObject.self
+            ) {
+              "Identify the primary object in this image. Be as specific as possible, categorize it, and provide a short 2-sentence description."
+              Attachment(cgImage).label("image")
+            }
+            if !Task.isCancelled {
+              self.identifiedObject = response.content
+            }
+            return
+          } catch {
+            if error.isMLAssetUnavailable {
+              print(
+                "Local ML assets unavailable for Vision ID. Falling back to cloud model..."
+              )
+            } else {
+              print(
+                "Local model failed for Vision ID: \(error.localizedDescription). Falling back to cloud model..."
+              )
+            }
+          }
+        }
+
+        // Fallback to cloud model
+        isUsingLocalModel = false
         do {
+          let ai = getFirebaseAI()
+          let model = ai.geminiLanguageModel(name: "gemini-3.5-flash")
           let session = LanguageModelSession(
-            model: SystemLanguageModel.default,
+            model: model,
             instructions: instructions
           )
           let response = try await session.respond(
@@ -58,48 +90,16 @@ final class VisionIDViewModel: FoundationModelsBaseViewModel {
             "Identify the primary object in this image. Be as specific as possible, categorize it, and provide a short 2-sentence description."
             Attachment(cgImage).label("image")
           }
+
           if !Task.isCancelled {
             self.identifiedObject = response.content
           }
-          return
         } catch {
-          if error.isMLAssetUnavailable {
-            print(
-              "Local ML assets unavailable for Vision ID. Falling back to cloud model..."
-            )
-          } else {
-            print(
-              "Local model failed for Vision ID: \(error.localizedDescription). Falling back to cloud model..."
-            )
+          if !Task.isCancelled {
+            self.error = error
           }
-        }
-      }
-
-      // Fallback to cloud model
-      isUsingLocalModel = false
-      do {
-        let ai = getFirebaseAI()
-        let model = ai.geminiLanguageModel(name: "gemini-3.5-flash")
-        let session = LanguageModelSession(
-          model: model,
-          instructions: instructions
-        )
-        let response = try await session.respond(
-          generating: IdentifiedObject.self
-        ) {
-          "Identify the primary object in this image. Be as specific as possible, categorize it, and provide a short 2-sentence description."
-          Attachment(cgImage).label("image")
-        }
-
-        if !Task.isCancelled {
-          self.identifiedObject = response.content
-        }
-      } catch {
-        if !Task.isCancelled {
-          self.error = error
         }
       }
     }
   }
-}
 #endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/FoundationModelsContainer.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/FoundationModelsContainer.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && compiler(>=6.4)
   import SwiftUI
 
   @available(iOS 27.0, *)

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/FoundationModelsContainer.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/FoundationModelsContainer.swift
@@ -59,7 +59,7 @@
           }
         }
       }
-      .sheet(isPresented: $presentErrorDetails) {
+      .sheet(isPresented: $presentErrorDetails, onDismiss: { viewModel.error = nil }) {
         if let error = viewModel.error {
           ErrorDetailsView(error: error)
         }

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/FoundationModelsContainer.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/FoundationModelsContainer.swift
@@ -13,62 +13,62 @@
 // limitations under the License.
 
 #if canImport(FoundationModels)
-import SwiftUI
+  import SwiftUI
 
-@available(iOS 27.0, *)
-struct FoundationModelsContainer<Content: View, VM: FoundationModelsBaseViewModel>: View {
-  @ObservedObject var viewModel: VM
-  @State private var presentErrorDetails = false
-  let title: String
-  let content: (VM) -> Content
+  @available(iOS 27.0, *)
+  struct FoundationModelsContainer<Content: View, VM: FoundationModelsBaseViewModel>: View {
+    @ObservedObject var viewModel: VM
+    @State private var presentErrorDetails = false
+    let title: String
+    let content: (VM) -> Content
 
-  var body: some View {
-    ZStack {
-      ScrollView {
-        content(viewModel)
-          .padding()
-          .frame(maxWidth: .infinity, alignment: .topLeading)
-      }
-
-      if viewModel.inProgress {
-        ProgressOverlay()
-      }
-    }
-    .background(Color(.systemGroupedBackground))
-    .navigationTitle(title)
-    .navigationBarTitleDisplayMode(.inline)
-    .toolbar {
-      ToolbarItemGroup(placement: .topBarTrailing) {
-        if viewModel.inProgress {
-          Button(action: {
-            viewModel.stopActiveTask()
-          }) {
-            Image(systemName: "stop.circle")
-              .font(.title3)
-          }
+    var body: some View {
+      ZStack {
+        ScrollView {
+          content(viewModel)
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
 
-        Menu {
-          Picker("Model Preference", selection: $viewModel.modelPreference) {
-            ForEach(ModelPreference.allCases) { pref in
-              Text(pref.rawValue).tag(pref)
+        if viewModel.inProgress {
+          ProgressOverlay()
+        }
+      }
+      .background(Color(.systemGroupedBackground))
+      .navigationTitle(title)
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItemGroup(placement: .topBarTrailing) {
+          if viewModel.inProgress {
+            Button(action: {
+              viewModel.stopActiveTask()
+            }) {
+              Image(systemName: "stop.circle")
+                .font(.title3)
             }
           }
-        } label: {
-          Image(systemName: "cpu")
+
+          Menu {
+            Picker("Model Preference", selection: $viewModel.modelPreference) {
+              ForEach(ModelPreference.allCases) { pref in
+                Text(pref.rawValue).tag(pref)
+              }
+            }
+          } label: {
+            Image(systemName: "cpu")
+          }
         }
       }
-    }
-    .sheet(isPresented: $presentErrorDetails) {
-      if let error = viewModel.error {
-        ErrorDetailsView(error: error)
+      .sheet(isPresented: $presentErrorDetails) {
+        if let error = viewModel.error {
+          ErrorDetailsView(error: error)
+        }
       }
-    }
-    .onChange(of: viewModel.error != nil) { oldValue, newValue in
-      if newValue {
-        presentErrorDetails = true
+      .onChange(of: viewModel.error != nil) { oldValue, newValue in
+        if newValue {
+          presentErrorDetails = true
+        }
       }
     }
   }
-}
 #endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/FoundationModelsContainer.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/FoundationModelsContainer.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationModels)
 import SwiftUI
 
 @available(iOS 27.0, *)
@@ -70,3 +71,4 @@ struct FoundationModelsContainer<Content: View, VM: FoundationModelsBaseViewMode
     }
   }
 }
+#endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/HybridAIView.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/HybridAIView.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && compiler(>=6.4)
   import SwiftUI
 
   @available(iOS 27.0, *)

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/HybridAIView.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/HybridAIView.swift
@@ -13,68 +13,68 @@
 // limitations under the License.
 
 #if canImport(FoundationModels)
-import SwiftUI
+  import SwiftUI
 
-@available(iOS 27.0, *)
-struct HybridAIView: View {
-  @ObservedObject var viewModel: HybridAIViewModel
+  @available(iOS 27.0, *)
+  struct HybridAIView: View {
+    @ObservedObject var viewModel: HybridAIViewModel
 
-  var body: some View {
-    VStack(alignment: .leading, spacing: 16) {
-      VStack(alignment: .leading, spacing: 8) {
-        Text("Input Text")
-          .font(.headline)
-        TextEditor(text: $viewModel.inputText)
-          .frame(height: 120)
-          .padding(4)
-          .background(Color(.secondarySystemGroupedBackground))
-          .cornerRadius(8)
-      }
-
-      Button(action: {
-        viewModel.runSummarization()
-      }) {
-        HStack {
-          Spacer()
-          Image(systemName: "sparkles")
-          Text("Summarise")
-          Spacer()
+    var body: some View {
+      VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 8) {
+          Text("Input Text")
+            .font(.headline)
+          TextEditor(text: $viewModel.inputText)
+            .frame(height: 120)
+            .padding(4)
+            .background(Color(.secondarySystemGroupedBackground))
+            .cornerRadius(8)
         }
-        .padding()
-        .foregroundColor(.white)
-        .background(Color.blue)
-        .cornerRadius(10)
-      }
-      .disabled(viewModel.inProgress)
 
-      if let summary = viewModel.outputSummary {
-        VStack(alignment: .leading, spacing: 12) {
+        Button(action: {
+          viewModel.runSummarization()
+        }) {
           HStack {
-            Text("Summary Points")
-              .font(.headline)
             Spacer()
-
-            ModelIndicatorView(isUsingLocalModel: viewModel.isUsingLocalModel)
-          }
-
-          VStack(alignment: .leading, spacing: 8) {
-            ForEach(summary.summaryPoints, id: \.self) { point in
-              HStack(alignment: .top, spacing: 6) {
-                Text("•")
-                  .bold()
-                Text(point)
-                  .font(.subheadline)
-              }
-            }
+            Image(systemName: "sparkles")
+            Text("Summarise")
+            Spacer()
           }
           .padding()
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .background(Color(.secondarySystemGroupedBackground))
+          .foregroundColor(.white)
+          .background(Color.blue)
           .cornerRadius(10)
         }
-        .transition(.opacity.combined(with: .slide))
+        .disabled(viewModel.inProgress)
+
+        if let summary = viewModel.outputSummary {
+          VStack(alignment: .leading, spacing: 12) {
+            HStack {
+              Text("Summary Points")
+                .font(.headline)
+              Spacer()
+
+              ModelIndicatorView(isUsingLocalModel: viewModel.isUsingLocalModel)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+              ForEach(summary.summaryPoints, id: \.self) { point in
+                HStack(alignment: .top, spacing: 6) {
+                  Text("•")
+                    .bold()
+                  Text(point)
+                    .font(.subheadline)
+                }
+              }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(.secondarySystemGroupedBackground))
+            .cornerRadius(10)
+          }
+          .transition(.opacity.combined(with: .slide))
+        }
       }
     }
   }
-}
 #endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/HybridAIView.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/HybridAIView.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationModels)
 import SwiftUI
 
 @available(iOS 27.0, *)
@@ -76,3 +77,4 @@ struct HybridAIView: View {
     }
   }
 }
+#endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/HybridAIView.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/HybridAIView.swift
@@ -26,6 +26,7 @@
             .font(.headline)
           TextEditor(text: $viewModel.inputText)
             .frame(height: 120)
+            .scrollContentBackground(.hidden)
             .padding(4)
             .background(Color(.secondarySystemGroupedBackground))
             .cornerRadius(8)

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/VisionIDView.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/VisionIDView.swift
@@ -51,13 +51,12 @@
             }
           }
         }
-        .onChange(of: photosPickerItem) { oldItem, newItem in
-          Task {
-            if let data = try? await newItem?.loadTransferable(type: Data.self),
-              let image = UIImage(data: data) {
-              viewModel.selectedImage = image
-              viewModel.identifySelectedImage()
-            }
+        .task(id: photosPickerItem) {
+          guard let photosPickerItem else { return }
+          if let data = try? await photosPickerItem.loadTransferable(type: Data.self),
+            let image = UIImage(data: data) {
+            viewModel.selectedImage = image
+            viewModel.identifySelectedImage()
           }
         }
 

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/VisionIDView.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/VisionIDView.swift
@@ -13,89 +13,89 @@
 // limitations under the License.
 
 #if canImport(FoundationModels)
-import SwiftUI
-import PhotosUI
+  import SwiftUI
+  import PhotosUI
 
-@available(iOS 27.0, *)
-@MainActor
-struct VisionIDView: View {
-  @ObservedObject var viewModel: VisionIDViewModel
-  @Binding var photosPickerItem: PhotosPickerItem?
-
+  @available(iOS 27.0, *)
   @MainActor
-  var body: some View {
-    let selectedImage = viewModel.selectedImage
+  struct VisionIDView: View {
+    @ObservedObject var viewModel: VisionIDViewModel
+    @Binding var photosPickerItem: PhotosPickerItem?
 
-    VStack(alignment: .leading, spacing: 16) {
-      Text("Select or Snap a Photo to Identify")
-        .font(.headline)
+    @MainActor
+    var body: some View {
+      let selectedImage = viewModel.selectedImage
 
-      PhotosPicker(selection: $photosPickerItem, matching: .images) {
-        VStack(spacing: 12) {
-          if let image = selectedImage {
-            Image(uiImage: image)
-              .resizable()
-              .aspectRatio(contentMode: .fit)
-              .frame(maxHeight: 200)
+      VStack(alignment: .leading, spacing: 16) {
+        Text("Select or Snap a Photo to Identify")
+          .font(.headline)
+
+        PhotosPicker(selection: $photosPickerItem, matching: .images) {
+          VStack(spacing: 12) {
+            if let image = selectedImage {
+              Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxHeight: 200)
+                .cornerRadius(12)
+            } else {
+              VStack(spacing: 8) {
+                Image(systemName: "photo.badge.plus")
+                  .font(.system(size: 40))
+                Text("Select an Image")
+              }
+              .frame(maxWidth: .infinity)
+              .frame(height: 180)
+              .background(Color(.secondarySystemGroupedBackground))
               .cornerRadius(12)
-          } else {
-            VStack(spacing: 8) {
-              Image(systemName: "photo.badge.plus")
-                .font(.system(size: 40))
-              Text("Select an Image")
             }
-            .frame(maxWidth: .infinity)
-            .frame(height: 180)
+          }
+        }
+        .onChange(of: photosPickerItem) { oldItem, newItem in
+          Task {
+            if let data = try? await newItem?.loadTransferable(type: Data.self),
+              let image = UIImage(data: data) {
+              viewModel.selectedImage = image
+              viewModel.identifySelectedImage()
+            }
+          }
+        }
+
+        if let identified = viewModel.identifiedObject {
+          VStack(alignment: .leading, spacing: 12) {
+            HStack {
+              Text("Identification Result")
+                .font(.headline)
+              Spacer()
+              ModelIndicatorView(isUsingLocalModel: viewModel.isUsingLocalModel)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+              HStack {
+                Text("Name:")
+                  .bold()
+                Text(identified.name)
+              }
+              HStack {
+                Text("Category:")
+                  .bold()
+                Text(identified.category)
+              }
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Description:")
+                  .bold()
+                Text(identified.description)
+                  .foregroundColor(.secondary)
+              }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color(.secondarySystemGroupedBackground))
-            .cornerRadius(12)
+            .cornerRadius(10)
           }
+          .transition(.opacity)
         }
-      }
-      .onChange(of: photosPickerItem) { oldItem, newItem in
-        Task {
-          if let data = try? await newItem?.loadTransferable(type: Data.self),
-            let image = UIImage(data: data) {
-            viewModel.selectedImage = image
-            viewModel.identifySelectedImage()
-          }
-        }
-      }
-
-      if let identified = viewModel.identifiedObject {
-        VStack(alignment: .leading, spacing: 12) {
-          HStack {
-            Text("Identification Result")
-              .font(.headline)
-            Spacer()
-            ModelIndicatorView(isUsingLocalModel: viewModel.isUsingLocalModel)
-          }
-
-          VStack(alignment: .leading, spacing: 8) {
-            HStack {
-              Text("Name:")
-                .bold()
-              Text(identified.name)
-            }
-            HStack {
-              Text("Category:")
-                .bold()
-              Text(identified.category)
-            }
-            VStack(alignment: .leading, spacing: 4) {
-              Text("Description:")
-                .bold()
-              Text(identified.description)
-                .foregroundColor(.secondary)
-            }
-          }
-          .padding()
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .background(Color(.secondarySystemGroupedBackground))
-          .cornerRadius(10)
-        }
-        .transition(.opacity)
       }
     }
   }
-}
 #endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/VisionIDView.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/VisionIDView.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationModels)
 import SwiftUI
 import PhotosUI
 
@@ -97,3 +98,4 @@ struct VisionIDView: View {
     }
   }
 }
+#endif

--- a/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/VisionIDView.swift
+++ b/firebaseai/FirebaseAIExample/Features/AppleFoundationModels/Views/VisionIDView.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && compiler(>=6.4)
   import SwiftUI
   import PhotosUI
 

--- a/firebaseai/FirebaseAIExample/Shared/Util/MLErrorHelper.swift
+++ b/firebaseai/FirebaseAIExample/Shared/Util/MLErrorHelper.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import Foundation
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && compiler(>=6.4)
   import FoundationModels
 #endif
 
@@ -22,7 +22,7 @@ extension Error {
   /// are missing from the device or simulator.
   var isMLAssetUnavailable: Bool {
     // 1. Check for LanguageModelSession.GenerationError.assetsUnavailable
-    #if canImport(FoundationModels)
+    #if canImport(FoundationModels) && compiler(>=6.4)
       if #available(iOS 26.0, *) {
         if let genError = self as? LanguageModelSession.GenerationError {
           if case .assetsUnavailable = genError {

--- a/firebaseai/FirebaseAIExample/Shared/Util/MLErrorHelper.swift
+++ b/firebaseai/FirebaseAIExample/Shared/Util/MLErrorHelper.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 #if canImport(FoundationModels)
-import FoundationModels
+  import FoundationModels
 #endif
 
 extension Error {
@@ -23,13 +23,13 @@ extension Error {
   var isMLAssetUnavailable: Bool {
     // 1. Check for LanguageModelSession.GenerationError.assetsUnavailable
     #if canImport(FoundationModels)
-    if #available(iOS 26.0, *) {
-      if let genError = self as? LanguageModelSession.GenerationError {
-        if case .assetsUnavailable = genError {
-          return true
+      if #available(iOS 26.0, *) {
+        if let genError = self as? LanguageModelSession.GenerationError {
+          if case .assetsUnavailable = genError {
+            return true
+          }
         }
       }
-    }
     #endif
 
     let nsError = self as NSError

--- a/firebaseai/FirebaseAIExample/Shared/Util/MLErrorHelper.swift
+++ b/firebaseai/FirebaseAIExample/Shared/Util/MLErrorHelper.swift
@@ -13,13 +13,16 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FoundationModels)
 import FoundationModels
+#endif
 
 extension Error {
   /// Returns true if this error indicates that required ML assets (like safety guardrails)
   /// are missing from the device or simulator.
   var isMLAssetUnavailable: Bool {
     // 1. Check for LanguageModelSession.GenerationError.assetsUnavailable
+    #if canImport(FoundationModels)
     if #available(iOS 26.0, *) {
       if let genError = self as? LanguageModelSession.GenerationError {
         if case .assetsUnavailable = genError {
@@ -27,6 +30,7 @@ extension Error {
         }
       }
     }
+    #endif
 
     let nsError = self as NSError
 


### PR DESCRIPTION
This PR wraps all new Apple Intelligence `FoundationModels` code pathways and navigation routes inside `#if canImport(FoundationModels)` compile-time checks. This allows the project to build successfully on older SDK targets (like Xcode 16.4/iOS 18.5) where the `FoundationModels` framework does not exist.